### PR TITLE
Add GitHub Actions to build on push and pull request

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,23 @@
+name: Java CI with Gradle
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: build-artifacts
+        path: build/libs


### PR DESCRIPTION
Also uploads build artifacts so that users can easily get pre-release builds, *if* they know how to use GitHub Actions *and* have a GitHub Account (will likely stop a flood of bug reports, but will mean people savvy enough will both have easier access to these builds and will also mean that you can get issue reports, which will likely be of a higher quality, so that you can fix bugs that you haven't (yet) noticed).

If you want me to change the JDK version (or anything else), I can do it easily.