### PR TITLE
Delete unnecessary faces from models, add cullface where it makes sense

### DIFF
--- a/src/main/resources/assets/minecraft/models/block/template_bed_foot.json
+++ b/src/main/resources/assets/minecraft/models/block/template_bed_foot.json
@@ -12,10 +12,9 @@
 			"faces": {
 				"north": {"uv": [14.75, 0.75, 15.5, 1.5], "texture": "#bed"},
 				"east": {"uv": [14, 0.75, 14.75, 1.5], "texture": "#bed"},
-				"south": {"uv": [13.25, 0.75, 14, 1.5], "texture": "#bed"},
-				"west": {"uv": [12.5, 0.75, 13.25, 1.5], "texture": "#bed"},
-				"up": {"uv": [13.25, 0, 14, 0.75], "rotation": 180, "texture": "#bed"},
-				"down": {"uv": [14, 0, 14.75, 0.75], "texture": "#bed"}
+				"south": {"uv": [13.25, 0.75, 14, 1.5], "texture": "#bed", "cullface": "south"},
+				"west": {"uv": [12.5, 0.75, 13.25, 1.5], "texture": "#bed", "cullface": "west"},
+				"down": {"uv": [14, 0, 14.75, 0.75], "texture": "#bed", "cullface": "down"}
 			}
 		},
 		{
@@ -24,11 +23,10 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [14.5, 0, 14.5]},
 			"faces": {
 				"north": {"uv": [14, 3.75, 14.75, 4.5], "texture": "#bed"},
-				"east": {"uv": [13.25, 3.75, 14, 4.5], "texture": "#bed"},
-				"south": {"uv": [12.5, 3.75, 13.25, 4.5], "texture": "#bed"},
+				"east": {"uv": [13.25, 3.75, 14, 4.5], "texture": "#bed", "cullface": "east"},
+				"south": {"uv": [12.5, 3.75, 13.25, 4.5], "texture": "#bed", "cullface": "south"},
 				"west": {"uv": [14.75, 3.75, 15.5, 4.5], "texture": "#bed"},
-				"up": {"uv": [13.25, 3, 14, 3.75], "rotation": 270, "texture": "#bed"},
-				"down": {"uv": [14, 3, 14.75, 3.75], "rotation": 90, "texture": "#bed"}
+				"down": {"uv": [14, 3, 14.75, 3.75], "rotation": 90, "texture": "#bed", "cullface": "down"}
 			}
 		},
 		{
@@ -36,10 +34,9 @@
 			"to": [16, 9, 16],
 			"rotation": {"angle": 0, "axis": "x", "origin": [0, 3, 16]},
 			"faces": {
-				"north": {"uv": [1.5, 5.5, 5.5, 7], "rotation": 180, "texture": "#bed"},
-				"east": {"uv": [5.5, 7, 7, 11], "rotation": 90, "texture": "#bed"},
-				"south": {"uv": [5.5, 5.5, 9.5, 7], "rotation": 180, "texture": "#bed"},
-				"west": {"uv": [0, 7, 1.5, 11], "rotation": 270, "texture": "#bed"},
+				"east": {"uv": [5.5, 7, 7, 11], "rotation": 90, "texture": "#bed", "cullface": "east"},
+				"south": {"uv": [5.5, 5.5, 9.5, 7], "rotation": 180, "texture": "#bed", "cullface": "south"},
+				"west": {"uv": [0, 7, 1.5, 11], "rotation": 270, "texture": "#bed", "cullface": "west"},
 				"up": {"uv": [1.5, 7, 5.5, 11], "texture": "#bed"},
 				"down": {"uv": [7, 7, 11, 11], "rotation": 180, "texture": "#bed"}
 			}

--- a/src/main/resources/assets/minecraft/models/block/template_bed_foot_ao.json
+++ b/src/main/resources/assets/minecraft/models/block/template_bed_foot_ao.json
@@ -11,10 +11,9 @@
 			"faces": {
 				"north": {"uv": [14.75, 0.75, 15.5, 1.5], "texture": "#bed"},
 				"east": {"uv": [14, 0.75, 14.75, 1.5], "texture": "#bed"},
-				"south": {"uv": [13.25, 0.75, 14, 1.5], "texture": "#bed"},
-				"west": {"uv": [12.5, 0.75, 13.25, 1.5], "texture": "#bed"},
-				"up": {"uv": [13.25, 0, 14, 0.75], "rotation": 180, "texture": "#bed"},
-				"down": {"uv": [14, 0, 14.75, 0.75], "texture": "#bed"}
+				"south": {"uv": [13.25, 0.75, 14, 1.5], "texture": "#bed", "cullface": "south"},
+				"west": {"uv": [12.5, 0.75, 13.25, 1.5], "texture": "#bed", "cullface": "west"},
+				"down": {"uv": [14, 0, 14.75, 0.75], "texture": "#bed", "cullface": "down"}
 			}
 		},
 		{
@@ -23,21 +22,19 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [14.5, 0, 14.5]},
 			"faces": {
 				"north": {"uv": [14, 3.75, 14.75, 4.5], "texture": "#bed"},
-				"east": {"uv": [13.25, 3.75, 14, 4.5], "texture": "#bed"},
-				"south": {"uv": [12.5, 3.75, 13.25, 4.5], "texture": "#bed"},
+				"east": {"uv": [13.25, 3.75, 14, 4.5], "texture": "#bed", "cullface": "east"},
+				"south": {"uv": [12.5, 3.75, 13.25, 4.5], "texture": "#bed", "cullface": "south"},
 				"west": {"uv": [14.75, 3.75, 15.5, 4.5], "texture": "#bed"},
-				"up": {"uv": [13.25, 3, 14, 3.75], "rotation": 270, "texture": "#bed"},
-				"down": {"uv": [14, 3, 14.75, 3.75], "rotation": 90, "texture": "#bed"}
+				"down": {"uv": [14, 3, 14.75, 3.75], "rotation": 90, "texture": "#bed", "cullface": "down"}
 			}
 		},
 		{
 			"from": [0, 3, 0],
 			"to": [16, 9, 16],
 			"faces": {
-				"north": {"uv": [1.5, 5.5, 5.5, 7], "texture": "#bed"},
-				"east": {"uv": [5.5, 7, 7, 11], "rotation": 90, "texture": "#bed"},
-				"south": {"uv": [5.5, 5.5, 9.5, 7], "rotation": 180, "texture": "#bed"},
-				"west": {"uv": [0, 7, 1.5, 11], "rotation": 270, "texture": "#bed"},
+				"east": {"uv": [5.5, 7, 7, 11], "rotation": 90, "texture": "#bed", "cullface": "east"},
+				"south": {"uv": [5.5, 5.5, 9.5, 7], "rotation": 180, "texture": "#bed", "cullface": "south"},
+				"west": {"uv": [0, 7, 1.5, 11], "rotation": 270, "texture": "#bed", "cullface": "west"},
 				"up": {"uv": [1.5, 7, 5.5, 11], "texture": "#bed"},
 				"down": {"uv": [7, 7, 11, 11], "texture": "#bed"}
 			}

--- a/src/main/resources/assets/minecraft/models/block/template_bed_head.json
+++ b/src/main/resources/assets/minecraft/models/block/template_bed_head.json
@@ -10,24 +10,22 @@
 			"to": [3, 3, 3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [1.5, 0, 1.5]},
 			"faces": {
-				"north": {"uv": [12.5, 2.25, 13.25, 3], "texture": "#bed"},
+				"north": {"uv": [12.5, 2.25, 13.25, 3], "texture": "#bed", "cullface": "north"},
 				"east": {"uv": [14.75, 2.25, 15.5, 3], "texture": "#bed"},
 				"south": {"uv": [14, 2.25, 14.75, 3], "texture": "#bed"},
-				"west": {"uv": [13.25, 2.25, 14, 3], "texture": "#bed"},
-				"up": {"uv": [13.25, 1.5, 14, 2.25], "rotation": 270, "texture": "#bed"},
-				"down": {"uv": [14, 1.5, 14.75, 2.25], "rotation": 270, "texture": "#bed"}
+				"west": {"uv": [13.25, 2.25, 14, 3], "texture": "#bed", "cullface": "west"},
+				"down": {"uv": [14, 1.5, 14.75, 2.25], "rotation": 270, "texture": "#bed", "cullface": "down"}
 			}
 		},
 		{
 			"from": [13, 0, 0],
 			"to": [16, 3, 3],
 			"faces": {
-				"north": {"uv": [13.25, 5.25, 14, 6], "texture": "#bed"},
-				"east": {"uv": [12.5, 5.25, 13.25, 6], "texture": "#bed"},
+				"north": {"uv": [13.25, 5.25, 14, 6], "texture": "#bed", "cullface": "north"},
+				"east": {"uv": [12.5, 5.25, 13.25, 6], "texture": "#bed", "cullface": "east"},
 				"south": {"uv": [14.75, 5.25, 15.5, 6], "texture": "#bed"},
 				"west": {"uv": [14, 5.25, 14.75, 6], "texture": "#bed"},
-				"up": {"uv": [13.25, 4.5, 14, 5.25], "rotation": 180, "texture": "#bed"},
-				"down": {"uv": [14, 4.5, 14.75, 5.25], "rotation": 180, "texture": "#bed"}
+				"down": {"uv": [14, 4.5, 14.75, 5.25], "rotation": 180, "texture": "#bed", "cullface": "down"}
 			}
 		},
 		{
@@ -35,10 +33,9 @@
 			"to": [16, 9, 16],
 			"rotation": {"angle": 0, "axis": "x", "origin": [0, 3, 16]},
 			"faces": {
-				"north": {"uv": [1.5, 0, 5.5, 1.5], "rotation": 180, "texture": "#bed"},
-				"east": {"uv": [5.5, 1.5, 7, 5.5], "rotation": 90, "texture": "#bed"},
-				"south": {"uv": [5.5, 0, 9.5, 1.5], "texture": "#bed"},
-				"west": {"uv": [0, 1.5, 1.5, 5.5], "rotation": 270, "texture": "#bed"},
+				"north": {"uv": [1.5, 0, 5.5, 1.5], "rotation": 180, "texture": "#bed", "cullface": "north"},
+				"east": {"uv": [5.5, 1.5, 7, 5.5], "rotation": 90, "texture": "#bed", "cullface": "east"},
+				"west": {"uv": [0, 1.5, 1.5, 5.5], "rotation": 270, "texture": "#bed", "cullface": "west"},
 				"up": {"uv": [1.5, 1.5, 5.5, 5.5], "texture": "#bed"},
 				"down": {"uv": [7, 1.5, 11, 5.5], "rotation": 180, "texture": "#bed"}
 			}

--- a/src/main/resources/assets/minecraft/models/block/template_bed_head_ao.json
+++ b/src/main/resources/assets/minecraft/models/block/template_bed_head_ao.json
@@ -9,34 +9,31 @@
 			"to": [3, 3, 3],
 			"rotation": {"angle": 0, "axis": "y", "origin": [1.5, 0, 1.5]},
 			"faces": {
-				"north": {"uv": [12.5, 2.25, 13.25, 3], "texture": "#bed"},
+				"north": {"uv": [12.5, 2.25, 13.25, 3], "texture": "#bed", "cullface": "north"},
 				"east": {"uv": [14.75, 2.25, 15.5, 3], "texture": "#bed"},
 				"south": {"uv": [14, 2.25, 14.75, 3], "texture": "#bed"},
-				"west": {"uv": [13.25, 2.25, 14, 3], "texture": "#bed"},
-				"up": {"uv": [13.25, 1.5, 14, 2.25], "rotation": 270, "texture": "#bed"},
-				"down": {"uv": [14, 1.5, 14.75, 2.25], "rotation": 270, "texture": "#bed"}
+				"west": {"uv": [13.25, 2.25, 14, 3], "texture": "#bed", "cullface": "west"},
+				"down": {"uv": [14, 1.5, 14.75, 2.25], "rotation": 270, "texture": "#bed", "cullface": "down"}
 			}
 		},
 		{
 			"from": [13, 0, 0],
 			"to": [16, 3, 3],
 			"faces": {
-				"north": {"uv": [13.25, 5.25, 14, 6], "texture": "#bed"},
-				"east": {"uv": [12.5, 5.25, 13.25, 6], "texture": "#bed"},
+				"north": {"uv": [13.25, 5.25, 14, 6], "texture": "#bed", "cullface": "north"},
+				"east": {"uv": [12.5, 5.25, 13.25, 6], "texture": "#bed", "cullface": "east"},
 				"south": {"uv": [14.75, 5.25, 15.5, 6], "texture": "#bed"},
 				"west": {"uv": [14, 5.25, 14.75, 6], "texture": "#bed"},
-				"up": {"uv": [13.25, 4.5, 14, 5.25], "rotation": 180, "texture": "#bed"},
-				"down": {"uv": [14, 4.5, 14.75, 5.25], "rotation": 180, "texture": "#bed"}
+				"down": {"uv": [14, 4.5, 14.75, 5.25], "rotation": 180, "texture": "#bed", "cullface": "down"}
 			}
 		},
 		{
 			"from": [0, 3, 0],
 			"to": [16, 9, 16],
 			"faces": {
-				"north": {"uv": [1.5, 0, 5.5, 1.5], "rotation": 180, "texture": "#bed"},
-				"east": {"uv": [5.5, 1.5, 7, 5.5], "rotation": 90, "texture": "#bed"},
-				"south": {"uv": [5.5, 0, 9.5, 1.5], "texture": "#bed"},
-				"west": {"uv": [0, 1.5, 1.5, 5.5], "rotation": 270, "texture": "#bed"},
+				"north": {"uv": [1.5, 0, 5.5, 1.5], "rotation": 180, "texture": "#bed", "cullface": "north"},
+				"east": {"uv": [5.5, 1.5, 7, 5.5], "rotation": 90, "texture": "#bed", "cullface": "east"},
+				"west": {"uv": [0, 1.5, 1.5, 5.5], "rotation": 270, "texture": "#bed", "cullface": "west"},
 				"up": {"uv": [1.5, 1.5, 5.5, 5.5], "texture": "#bed"},
 				"down": {"uv": [7, 1.5, 11, 5.5], "texture": "#bed"}
 			}

--- a/src/main/resources/assets/minecraft/models/block/template_chest_center.json
+++ b/src/main/resources/assets/minecraft/models/block/template_chest_center.json
@@ -14,8 +14,7 @@
 				"east": {"uv": [0, 8.25, 3.5, 10.75], "rotation": 180, "texture": "#chest"},
 				"south": {"uv": [3.5, 8.25, 7, 10.75], "rotation": 180, "texture": "#chest"},
 				"west": {"uv": [7, 8.25, 10.5, 10.75], "rotation": 180, "texture": "#chest"},
-				"up": {"uv": [7, 4.75, 10.5, 8.25], "texture": "#chest"},
-				"down": {"uv": [3.5, 4.75, 7, 8.25], "texture": "#chest"}
+				"down": {"uv": [3.5, 4.75, 7, 8.25], "texture": "#chest", "cullface": "down"}
 			}
 		},
 		{
@@ -27,8 +26,7 @@
 				"east": {"uv": [0, 3.5, 3.5, 4.75], "rotation": 180, "texture": "#chest"},
 				"south": {"uv": [3.5, 3.5, 7, 4.75], "rotation": 180, "texture": "#chest"},
 				"west": {"uv": [7, 3.5, 10.5, 4.75], "rotation": 180, "texture": "#chest"},
-				"up": {"uv": [10.5, 0, 7, 3.5], "texture": "#chest"},
-				"down": {"uv": [3.5, 0, 7, 3.5], "texture": "#chest"}
+				"up": {"uv": [10.5, 0, 7, 3.5], "texture": "#chest"}
 			}
 		},
 		{
@@ -38,7 +36,6 @@
 			"faces": {
 				"north": {"uv": [1, 0.25, 1.5, 1.25], "rotation": 180, "texture": "#chest"},
 				"east": {"uv": [0, 0.25, 0.25, 1.25], "rotation": 180, "texture": "#chest"},
-				"south": {"uv": [0.25, 0.25, 0.75, 1.25], "rotation": 180, "texture": "#chest"},
 				"west": {"uv": [0.75, 0.25, 1, 1.25], "rotation": 180, "texture": "#chest"},
 				"up": {"uv": [1.25, 0, 0.75, 0.25], "texture": "#chest"},
 				"down": {"uv": [0.25, 0, 0.75, 0.25], "rotation": 180, "texture": "#chest"}

--- a/src/main/resources/assets/minecraft/models/block/template_chest_center_trunk.json
+++ b/src/main/resources/assets/minecraft/models/block/template_chest_center_trunk.json
@@ -15,7 +15,7 @@
 				"south": {"uv": [3.5, 8.25, 7, 10.75], "rotation": 180, "texture": "#chest"},
 				"west": {"uv": [7, 8.25, 10.5, 10.75], "rotation": 180, "texture": "#chest"},
 				"up": {"uv": [7, 4.75, 10.5, 8.25], "texture": "#chest"},
-				"down": {"uv": [3.5, 4.75, 7, 8.25], "texture": "#chest"}
+				"down": {"uv": [3.5, 4.75, 7, 8.25], "texture": "#chest", "cullface": "down"}
 			}
 		}
 	]

--- a/src/main/resources/assets/minecraft/models/block/template_chest_left.json
+++ b/src/main/resources/assets/minecraft/models/block/template_chest_left.json
@@ -11,11 +11,9 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [9, 8, 9]},
 			"faces": {
 				"north": {"uv": [10.75, 8.25, 14.5, 10.75], "rotation": 180, "texture": "#chest"},
-				"east": {"uv": [0, 8.25, 3.5, 10.75], "texture": "#chest"},
 				"south": {"uv": [3.5, 8.25, 7.25, 10.75], "rotation": 180, "texture": "#chest"},
 				"west": {"uv": [7.25, 8.25, 10.75, 10.75], "rotation": 180, "texture": "#chest"},
-				"up": {"uv": [11, 4.75, 7.25, 8.25], "texture": "#chest"},
-				"down": {"uv": [7.25, 4.75, 3.5, 8.25], "texture": "#chest"}
+				"down": {"uv": [7.25, 4.75, 3.5, 8.25], "texture": "#chest", "cullface": "down"}
 			}
 		},
 		{
@@ -24,11 +22,9 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [9, 17, 9]},
 			"faces": {
 				"north": {"uv": [10.75, 3.5, 14.5, 4.75], "rotation": 180, "texture": "#chest"},
-				"east": {"uv": [0, 3.5, 3.5, 4.75], "rotation": 180, "texture": "#chest"},
 				"south": {"uv": [3.5, 3.5, 7.25, 4.75], "rotation": 180, "texture": "#chest"},
 				"west": {"uv": [7.25, 3.5, 10.75, 4.75], "rotation": 180, "texture": "#chest"},
-				"up": {"uv": [11, 0, 7.25, 3.5], "texture": "#chest"},
-				"down": {"uv": [7.25, 0, 3.5, 3.5], "texture": "#chest"}
+				"up": {"uv": [11, 0, 7.25, 3.5], "texture": "#chest"}
 			}
 		},
 		{
@@ -37,8 +33,6 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [23, 15, 8]},
 			"faces": {
 				"north": {"uv": [0.75, 0.25, 1, 1.25], "rotation": 180, "texture": "#chest"},
-				"east": {"uv": [0, 0.25, 0.25, 1.25], "texture": "#chest"},
-				"south": {"uv": [0.25, 0.25, 0.5, 1.25], "texture": "#chest"},
 				"west": {"uv": [0.5, 0.25, 0.75, 1.25], "rotation": 180, "texture": "#chest"},
 				"up": {"uv": [0.5, 0, 0.75, 0.25], "texture": "#chest"},
 				"down": {"uv": [0.25, 0, 0.5, 0.25], "texture": "#chest"}

--- a/src/main/resources/assets/minecraft/models/block/template_chest_left_lid.json
+++ b/src/main/resources/assets/minecraft/models/block/template_chest_left_lid.json
@@ -11,7 +11,6 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [9, 17, 9]},
 			"faces": {
 				"north": {"uv": [10.75, 3.5, 14.5, 4.75], "rotation": 180, "texture": "#chest"},
-				"east": {"uv": [0, 3.5, 3.5, 4.75], "rotation": 180, "texture": "#chest"},
 				"south": {"uv": [3.5, 3.5, 7.25, 4.75], "rotation": 180, "texture": "#chest"},
 				"west": {"uv": [7.25, 3.5, 10.75, 4.75], "rotation": 180, "texture": "#chest"},
 				"up": {"uv": [11, 0, 7.25, 3.5], "texture": "#chest"},

--- a/src/main/resources/assets/minecraft/models/block/template_chest_left_trunk.json
+++ b/src/main/resources/assets/minecraft/models/block/template_chest_left_trunk.json
@@ -15,7 +15,7 @@
 				"south": {"uv": [3.5, 8.25, 7.25, 10.75], "rotation": 180, "texture": "#chest"},
 				"west": {"uv": [7.25, 8.25, 10.75, 10.75], "rotation": 180, "texture": "#chest"},
 				"up": {"uv": [11, 4.75, 7.25, 8.25], "texture": "#chest"},
-				"down": {"uv": [7.25, 4.75, 3.5, 8.25], "texture": "#chest"}
+				"down": {"uv": [7.25, 4.75, 3.5, 8.25], "texture": "#chest", "cullface": "down"}
 			}
 		}
 	]

--- a/src/main/resources/assets/minecraft/models/block/template_chest_right.json
+++ b/src/main/resources/assets/minecraft/models/block/template_chest_right.json
@@ -13,9 +13,7 @@
 				"north": {"uv": [10.75, 8.25, 14.5, 10.75], "rotation": 180, "texture": "#chest"},
 				"east": {"uv": [0, 8.25, 3.5, 10.75], "rotation": 180, "texture": "#chest"},
 				"south": {"uv": [3.5, 8.25, 7.25, 10.75], "rotation": 180, "texture": "#chest"},
-				"west": {"uv": [7.25, 8.25, 10.75, 10.75], "rotation": 180, "texture": "#chest"},
-				"up": {"uv": [11, 4.75, 7.25, 8.25], "texture": "#chest"},
-				"down": {"uv": [7.25, 4.75, 3.5, 8.25], "texture": "#chest"}
+				"down": {"uv": [7.25, 4.75, 3.5, 8.25], "texture": "#chest", "cullface": "down"}
 			}
 		},
 		{
@@ -26,9 +24,7 @@
 				"north": {"uv": [10.75, 3.5, 14.5, 4.75], "rotation": 180, "texture": "#chest"},
 				"east": {"uv": [0, 3.5, 3.5, 4.75], "rotation": 180, "texture": "#chest"},
 				"south": {"uv": [3.5, 3.5, 7.25, 4.75], "rotation": 180, "texture": "#chest"},
-				"west": {"uv": [7.25, 3.5, 10.75, 4.75], "rotation": 180, "texture": "#chest"},
-				"up": {"uv": [11, 0, 7.25, 3.5], "texture": "#chest"},
-				"down": {"uv": [7.25, 0, 3.5, 3.5], "texture": "#chest"}
+				"up": {"uv": [11, 0, 7.25, 3.5], "texture": "#chest"}
 			}
 		},
 		{
@@ -38,8 +34,6 @@
 			"faces": {
 				"north": {"uv": [0.75, 0.25, 1, 1.25], "rotation": 180, "texture": "#chest"},
 				"east": {"uv": [0, 0.25, 0.25, 1.25], "rotation": 180, "texture": "#chest"},
-				"south": {"uv": [0.25, 0.25, 0.5, 1.25], "texture": "#chest"},
-				"west": {"uv": [0.5, 0.25, 0.75, 1.25], "texture": "#chest"},
 				"up": {"uv": [0.5, 0, 0.75, 0.25], "texture": "#chest"},
 				"down": {"uv": [0.25, 0, 0.5, 0.25], "texture": "#chest"}
 			}

--- a/src/main/resources/assets/minecraft/models/block/template_chest_right_trunk.json
+++ b/src/main/resources/assets/minecraft/models/block/template_chest_right_trunk.json
@@ -15,7 +15,7 @@
 				"south": {"uv": [3.5, 8.25, 7.25, 10.75], "rotation": 180, "texture": "#chest"},
 				"west": {"uv": [7.25, 8.25, 10.75, 10.75], "rotation": 180, "texture": "#chest"},
 				"up": {"uv": [11, 4.75, 7.25, 8.25], "texture": "#chest"},
-				"down": {"uv": [7.25, 4.75, 3.5, 8.25], "texture": "#chest"}
+				"down": {"uv": [7.25, 4.75, 3.5, 8.25], "texture": "#chest", "cullface": "down"}
 			}
 		}
 	]

--- a/src/main/resources/assets/minecraft/models/block/template_sign_0.json
+++ b/src/main/resources/assets/minecraft/models/block/template_sign_0.json
@@ -13,8 +13,7 @@
 				"east": {"uv": [0, 8, 0.5, 15], "texture": "#sign"},
 				"south": {"uv": [1.5, 8, 2, 15], "texture": "#sign"},
 				"west": {"uv": [1, 8, 1.5, 15], "texture": "#sign"},
-				"up": {"uv": [0.5, 7, 1, 8], "texture": "#sign"},
-				"down": {"uv": [1, 7, 1.5, 8], "texture": "#sign"}
+				"down": {"uv": [1, 7, 1.5, 8], "texture": "#sign", "cullface": "down"}
 			}
 		},
 		{

--- a/src/main/resources/assets/minecraft/models/block/template_sign_0_ao.json
+++ b/src/main/resources/assets/minecraft/models/block/template_sign_0_ao.json
@@ -13,8 +13,7 @@
 				"east": {"uv": [0, 8, 0.5, 15], "texture": "#sign"},
 				"south": {"uv": [1.5, 8, 2, 15], "texture": "#sign"},
 				"west": {"uv": [1, 8, 1.5, 15], "texture": "#sign"},
-				"up": {"uv": [0.5, 7, 1, 8], "texture": "#sign"},
-				"down": {"uv": [1, 7, 1.5, 8], "texture": "#sign"}
+				"down": {"uv": [1, 7, 1.5, 8], "texture": "#sign", "cullface": "down"}
 			}
 		},
 		{

--- a/src/main/resources/assets/minecraft/models/block/template_sign_22_5.json
+++ b/src/main/resources/assets/minecraft/models/block/template_sign_22_5.json
@@ -14,8 +14,7 @@
 				"east": {"uv": [0, 8, 0.5, 15], "texture": "#sign"},
 				"south": {"uv": [1.5, 8, 2, 15], "texture": "#sign"},
 				"west": {"uv": [1, 8, 1.5, 15], "texture": "#sign"},
-				"up": {"uv": [0.5, 7, 1, 8], "texture": "#sign"},
-				"down": {"uv": [1, 7, 1.5, 8], "texture": "#sign"}
+				"down": {"uv": [1, 7, 1.5, 8], "texture": "#sign", "cullface": "down"}
 			}
 		},
 		{

--- a/src/main/resources/assets/minecraft/models/block/template_sign_22_5_ao.json
+++ b/src/main/resources/assets/minecraft/models/block/template_sign_22_5_ao.json
@@ -14,8 +14,7 @@
 				"east": {"uv": [0, 8, 0.5, 15], "texture": "#sign"},
 				"south": {"uv": [1.5, 8, 2, 15], "texture": "#sign"},
 				"west": {"uv": [1, 8, 1.5, 15], "texture": "#sign"},
-				"up": {"uv": [0.5, 7, 1, 8], "texture": "#sign"},
-				"down": {"uv": [1, 7, 1.5, 8], "texture": "#sign"}
+				"down": {"uv": [1, 7, 1.5, 8], "texture": "#sign", "cullface": "down"}
 			}
 		},
 		{

--- a/src/main/resources/assets/minecraft/models/block/template_sign_45.json
+++ b/src/main/resources/assets/minecraft/models/block/template_sign_45.json
@@ -14,8 +14,7 @@
 				"east": {"uv": [0, 8, 0.5, 15], "texture": "#sign"},
 				"south": {"uv": [1.5, 8, 2, 15], "texture": "#sign"},
 				"west": {"uv": [1, 8, 1.5, 15], "texture": "#sign"},
-				"up": {"uv": [0.5, 7, 1, 8], "texture": "#sign"},
-				"down": {"uv": [1, 7, 1.5, 8], "texture": "#sign"}
+				"down": {"uv": [1, 7, 1.5, 8], "texture": "#sign", "cullface": "down"}
 			}
 		},
 		{

--- a/src/main/resources/assets/minecraft/models/block/template_sign_45_ao.json
+++ b/src/main/resources/assets/minecraft/models/block/template_sign_45_ao.json
@@ -14,8 +14,7 @@
 				"east": {"uv": [0, 8, 0.5, 15], "texture": "#sign"},
 				"south": {"uv": [1.5, 8, 2, 15], "texture": "#sign"},
 				"west": {"uv": [1, 8, 1.5, 15], "texture": "#sign"},
-				"up": {"uv": [0.5, 7, 1, 8], "texture": "#sign"},
-				"down": {"uv": [1, 7, 1.5, 8], "texture": "#sign"}
+				"down": {"uv": [1, 7, 1.5, 8], "texture": "#sign", "cullface": "down"}
 			}
 		},
 		{

--- a/src/main/resources/assets/minecraft/models/block/template_sign_67_5.json
+++ b/src/main/resources/assets/minecraft/models/block/template_sign_67_5.json
@@ -14,8 +14,7 @@
 				"east": {"uv": [1.5, 8, 2, 15], "texture": "#sign"},
 				"south": {"uv": [1, 8, 1.5, 15], "texture": "#sign"},
 				"west": {"uv": [0.5, 8, 1, 15], "texture": "#sign"},
-				"up": {"uv": [0.5, 7, 1, 8], "rotation": 270, "texture": "#sign"},
-				"down": {"uv": [1, 7, 1.5, 8], "rotation": 90, "texture": "#sign"}
+				"down": {"uv": [1, 7, 1.5, 8], "rotation": 90, "texture": "#sign", "cullface": "down"}
 			}
 		},
 		{

--- a/src/main/resources/assets/minecraft/models/block/template_sign_67_5_ao.json
+++ b/src/main/resources/assets/minecraft/models/block/template_sign_67_5_ao.json
@@ -14,8 +14,7 @@
 				"east": {"uv": [1.5, 8, 2, 15], "texture": "#sign"},
 				"south": {"uv": [1, 8, 1.5, 15], "texture": "#sign"},
 				"west": {"uv": [0.5, 8, 1, 15], "texture": "#sign"},
-				"up": {"uv": [0.5, 7, 1, 8], "rotation": 270, "texture": "#sign"},
-				"down": {"uv": [1, 7, 1.5, 8], "rotation": 90, "texture": "#sign"}
+				"down": {"uv": [1, 7, 1.5, 8], "rotation": 90, "texture": "#sign", "cullface": "down"}
 			}
 		},
 		{

--- a/src/main/resources/assets/minecraft/models/block/template_wall_sign.json
+++ b/src/main/resources/assets/minecraft/models/block/template_wall_sign.json
@@ -11,9 +11,9 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3, 15]},
 			"faces": {
 				"north": {"uv": [0.5, 1, 6.5, 7], "texture": "#sign"},
-				"east": {"uv": [0, 1, 0.5, 7], "texture": "#sign"},
+				"east": {"uv": [0, 1, 0.5, 7], "texture": "#sign", "cullface": "east"},
 				"south": {"uv": [7, 1, 13, 7], "texture": "#sign"},
-				"west": {"uv": [6.5, 1, 7, 7], "texture": "#sign"},
+				"west": {"uv": [6.5, 1, 7, 7], "texture": "#sign", "cullface": "west"},
 				"up": {"uv": [0.5, 0, 6.5, 1], "texture": "#sign"},
 				"down": {"uv": [6.5, 0, 12.5, 1], "texture": "#sign"}
 			}

--- a/src/main/resources/assets/minecraft/models/block/template_wall_sign_ao.json
+++ b/src/main/resources/assets/minecraft/models/block/template_wall_sign_ao.json
@@ -11,9 +11,9 @@
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3, 15]},
 			"faces": {
 				"north": {"uv": [0.5, 1, 6.5, 7], "texture": "#sign"},
-				"east": {"uv": [0, 1, 0.5, 7], "texture": "#sign"},
+				"east": {"uv": [0, 1, 0.5, 7], "texture": "#sign", "cullface": "east"},
 				"south": {"uv": [7, 1, 13, 7], "texture": "#sign"},
-				"west": {"uv": [6.5, 1, 7, 7], "texture": "#sign"},
+				"west": {"uv": [6.5, 1, 7, 7], "texture": "#sign", "cullface": "west"},
 				"up": {"uv": [0.5, 0, 6.5, 1], "texture": "#sign"},
 				"down": {"uv": [6.5, 0, 12.5, 1], "texture": "#sign"}
 			}


### PR DESCRIPTION
These shouldn't cause any visual differences outside of Spectator or otherwise clipping into blocks in unexpected ways, but cuts down on model file size a bit. The game also doesn't need to render as much, which is also a bonus.

Fixes #77, fixes #78 (for the former, cullface was left out for sign tops since it'd look weird with carpets on top, as well as several faces which the game refuses to cull since the block's hitbox doesn't extend out far enough, such as the thin sides of standing signs as well as chest locks)