### PR TITLE
Fix a crash

### DIFF
--- a/src/main/java/foundationgames/enhancedblockentities/mixin/SignEditScreenMixin.java
+++ b/src/main/java/foundationgames/enhancedblockentities/mixin/SignEditScreenMixin.java
@@ -38,8 +38,10 @@ public class SignEditScreenMixin {
             BlockState state = this.sign.getCachedState();
             if (state.contains(Properties.HORIZONTAL_FACING)) {
                 state = state.with(Properties.HORIZONTAL_FACING, Direction.NORTH);
-            } else {
+            } else if (state.contains(Properties.ROTATION)) {
                 state = state.with(Properties.ROTATION, 0);
+            } else {
+                return;
             }
 
             var signModel = models.getModel(state);


### PR DESCRIPTION
The sign might not even actually be there when placed on some servers, so this crashes the client because it's trying to change a state which doesn't exist on a non-sign block