### PR TITLE
Fixed cullface for wall hanging signs

### DIFF
--- a/src/main/resources/assets/minecraft/models/block/template_wall_hanging_sign.json
+++ b/src/main/resources/assets/minecraft/models/block/template_wall_hanging_sign.json
@@ -72,7 +72,7 @@
 			"to": [16, 16, 10],
 			"faces": {
 				"north": {"uv": [1, 2, 5, 3], "texture": "#sign"},
-				"east": {"uv": [0, 2, 1, 3], "texture": "#sign", "cullface": "west"},
+				"east": {"uv": [0, 2, 1, 3], "texture": "#sign", "cullface": "east"},
 				"south": {"uv": [6, 2, 10, 3], "texture": "#sign"},
 				"west": {"uv": [5, 2, 6, 3], "texture": "#sign", "cullface": "west"},
 				"up": {"uv": [1, 2, 5, 0], "texture": "#sign", "cullface": "up"},


### PR DESCRIPTION
Replaced "cullface": "west" with "cullface": "east" for the east face

Referenced in #161 #224