### PR TITLE
[WIP/Draft] MC 26.2 port — rendering overhaul makes this non-trivial

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,29 +1,59 @@
-name: build
-on: [pull_request, push]
+name: Build
+
+on:
+  push:
+    branches: ["26.2"]
+  pull_request:
+    branches: ["26.2"]
+  workflow_dispatch:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        java: [21]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - name: checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v4
-      - name: validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v2
-      - name: setup jdk ${{ matrix.java }}
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v3
+
+      - name: Setup JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java }}
-          distribution: 'temurin'
-      - name: make gradle wrapper executable
+          java-version: 25
+          distribution: temurin
+          cache: gradle
+
+      - name: Make Gradle wrapper executable
         run: chmod +x ./gradlew
-      - name: build
+
+      - name: Build
         run: ./gradlew build
-      - name: capture build artifacts
-        if: ${{ matrix.java == '21' }}
+
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Artifacts
+          name: enhancedblockentities-26.2
+          path: build/libs/*.jar
+          if-no-files-found: error
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/26.2' && github.event_name == 'push'
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: enhancedblockentities-26.2
           path: build/libs/
+
+      - name: Create release draft
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref_name, '26.')
+        with:
+          draft: true
+          files: build/libs/*.jar
+          tag_name: ${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
+## ⚠️ Archival Notice (June 2026)
+
+> **This mod is likely no longer needed as of Minecraft Java Edition 26.2 (internal: 1.21.11).**
+>
+> Mojang completely overhauled the rendering pipeline in 26.x. The new architecture already addresses the core problems EBE was solving — see details below.
+>
+> **We propose this repository be archived.** If you disagree or have evidence the performance/visual gaps still exist in 26.x vanilla, please open an issue before archival.
+
+---
+
+### What happened to MC 26.2 support?
+
+A port to MC 26.2 was attempted in [PR #321](https://github.com/FoundationGames/EnhancedBlockEntities/pull/321). After ~8 hours of work, it became clear that a 1:1 port is not possible — the rendering system EBE is built on has been replaced:
+
+| EBE relied on | Removed/replaced in MC 26.x |
+|---|---|
+| `BakedModel` interface | Replaced by `BlockStateModel` (`net.minecraft.client.renderer.block.dispatch`) |
+| `BlockEntityRenderDispatcher.render(BlockEntityRenderer, BlockEntity, ...)` | Two-phase render: `BlockEntity` → `BlockEntityRenderState` → pixels |
+| `FabricBakedModelManager.getModel(Identifier)` | `FabricModelManager.getModel(ExtraModelKey<T>)` — typed key-based API |
+| `BlockRenderLayerMap` (Fabric API) | Removed entirely from Fabric API for 26.x |
+| `VertexConsumerProvider` / `MultiBufferSource` | Replaced by `SubmitNodeCollector` and new pipeline |
+
+Mojang's new **Entity Render State** system separates state extraction (game thread) from rendering (render thread), which provides the same caching and parallelism benefits EBE was delivering as a workaround. The new `BlockStateModel` pipeline already gets proper ambient occlusion and chunk-integrated lighting.
+
+The one remaining gap worth investigating: whether block entity render states get equivalent AO/lighting quality compared to static chunk geometry. If that gap exists in 26.x vanilla, a slimmer mod focused only on lighting quality (not full static baking) could still have value. If you want to explore this, check [PR #321](https://github.com/FoundationGames/EnhancedBlockEntities/pull/321) for a starting point.
+
+---
+
 ## Enhanced Block Entities
 
 EBE is a **100% client side** Minecraft mod for the **[Fabric](https://fabricmc.net/use/)** mod loader which aims to increase the performance of block entity rendering, as well as offer customizability via resource packs. <br/><br/>

--- a/build.gradle
+++ b/build.gradle
@@ -10,21 +10,21 @@ group = project.maven_group
 repositories {
 	maven { url = 'https://maven.terraformersmc.com/' }
 	maven { url = 'https://api.modrinth.com/maven/' }
+	maven { url = 'https://maven.fabricmc.net/' }
 }
 
 dependencies {
-	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	// Mod Menu for config screen
-	modApi "com.terraformersmc:modmenu:${project.modmenu_version}"
+	modCompileOnly "com.terraformersmc:modmenu:${project.modmenu_version}"
 
 	// Sodium for compatibility
-	modCompileOnlyApi "maven.modrinth:sodium:${project.sodium_version}"
+	modCompileOnly "maven.modrinth:sodium:${project.sodium_version}"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-	id 'fabric-loom' version '1.8-SNAPSHOT'
+	id 'net.fabricmc.fabric-loom' version "${loom_version}"
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_21
-targetCompatibility = JavaVersion.VERSION_21
+sourceCompatibility = JavaVersion.VERSION_25
+targetCompatibility = JavaVersion.VERSION_25
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -21,10 +21,10 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-	// Fabric API. This is technically optional, but you probably want it anyway.
+	// Fabric API
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	// Mod Menu because config screen access from another place
+	// Mod Menu for config screen
 	modApi "com.terraformersmc:modmenu:${project.modmenu_version}"
 
 	// Sodium for compatibility
@@ -40,17 +40,11 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	// ensure that the encoding is set to UTF-8, no matter what the system default is
-	// this fixes some edge cases with special characters not displaying correctly
-	// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-	// If Javadoc is generated, this must be specified in that task too.
 	it.options.encoding = "UTF-8"
+	it.options.release = 25
 }
 
 java {
-	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-	// if it is present.
-	// If you remove this line, sources will not be generated.
 	withSourcesJar()
 }
 
@@ -64,7 +58,6 @@ loom {
 	accessWidenerPath = file("src/main/resources/enhancedblockentities.accesswidener")
 }
 
-// configure the maven publication
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
@@ -72,9 +65,6 @@ publishing {
 		}
 	}
 
-	// Select the repositories you want to publish to
-	// To publish to maven local, no extra repositories are necessary. Just use the task `publishToMavenLocal`.
 	repositories {
-		// See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ repositories {
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,6 @@ plugins {
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_25
-targetCompatibility = JavaVersion.VERSION_25
-
 archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
@@ -45,6 +42,8 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 java {
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 	withSourcesJar()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'maven-publish'
 }
 
-archivesBaseName = project.archives_base_name
+base.archivesName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
@@ -49,7 +49,7 @@ java {
 
 jar {
 	from("LICENSE") {
-		rename { "${it}_${project.archivesBaseName}"}
+		rename { "${it}_${project.archives_base_name}"}
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,13 +18,13 @@ dependencies {
 	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	// Mod Menu for config screen
-	modCompileOnly "com.terraformersmc:modmenu:${project.modmenu_version}"
+	// Mod Menu for config screen (compile-only)
+	compileOnly "com.terraformersmc:modmenu:${project.modmenu_version}"
 
-	// Sodium for compatibility
-	modCompileOnly "maven.modrinth:sodium:${project.sodium_version}"
+	// Sodium for compatibility (compile-only)
+	compileOnly "maven.modrinth:sodium:${project.sodium_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,15 @@
 org.gradle.jvmargs=-Xmx2G
 
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.8
-loader_version=0.16.10
+minecraft_version=26.2
+yarn_mappings=1.21.11+build.6
+loader_version=0.19.3
+loom_version=1.17-SNAPSHOT
 
-fabric_version=0.114.3+1.21.4
+fabric_version=0.153.0+26.2
 
-mod_version = 0.11.4+1.21.4
+mod_version = 0.11.5+26.2
 maven_group = foundationgames
 archives_base_name = enhancedblockentities
 
-modmenu_version=13.0.0
-sodium_version=mc1.21.4-0.6.6-fabric
+modmenu_version=20.0.0-beta.4
+sodium_version=mc26.2-0.9.1-beta.2-fabric

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 minecraft_version=26.2
 yarn_mappings=1.21.11+build.6
 loader_version=0.19.3
-loom_version=1.17-SNAPSHOT
+loom_version=1.16.2
 
 fabric_version=0.153.0+26.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 minecraft_version=26.2
 yarn_mappings=1.21.11+build.6
 loader_version=0.19.3
-loom_version=1.16.2
+loom_version=1.17-SNAPSHOT
 
 fabric_version=0.153.0+26.2
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/foundationgames/enhancedblockentities/EBESetup.java
+++ b/src/main/java/foundationgames/enhancedblockentities/EBESetup.java
@@ -18,21 +18,20 @@ import foundationgames.enhancedblockentities.util.DateUtil;
 import foundationgames.enhancedblockentities.util.EBEUtil;
 import foundationgames.enhancedblockentities.util.ResourceUtil;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
-import net.fabricmc.fabric.api.client.model.loading.v1.FabricBakedModelManager;
 import net.fabricmc.fabric.api.client.model.loading.v1.ModelLoadingPlugin;
-import net.minecraft.block.Block;
-import net.minecraft.block.Blocks;
-import net.minecraft.block.ShulkerBoxBlock;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.block.entity.BlockEntityType;
-import net.minecraft.block.enums.ChestType;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.render.RenderLayer;
-import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.registry.Registries;
-import net.minecraft.state.property.Properties;
-import net.minecraft.util.DyeColor;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.ShulkerBoxBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.ChestType;
 
 import java.util.function.Function;
 
@@ -114,7 +113,7 @@ public enum EBESetup {;
     public static void setupRRPBells() {
         ResourceUtil.addBellBlockState(ResourceUtil.getPackForCompat());
 
-        ResourceUtil.getBasePack().addSingleBlockSprite(Identifier.of("entity/bell/bell_body"));
+        ResourceUtil.getBasePack().addSingleBlockSprite(ResourceLocation.parse("entity/bell/bell_body"));
     }
 
     public static void setupRRPBeds() {
@@ -137,7 +136,7 @@ public enum EBESetup {;
             var id = color != null ? color.getName()+"_shulker_box" : "shulker_box";
             ResourceUtil.addShulkerBoxBlockStates(color, pCompat);
             ResourceUtil.addShulkerBoxModels(color, p);
-            ResourceUtil.addParentModel("block/"+id, Identifier.of("item/"+id), p);
+            ResourceUtil.addParentModel("block/"+id, ResourceLocation.parse("item/"+id), p);
         }
 
         p.addDirBlockSprites("entity/shulker", "entity/shulker/");
@@ -148,7 +147,7 @@ public enum EBESetup {;
         EBEPack pCompat = ResourceUtil.getPackForCompat();
 
         ResourceUtil.addDecoratedPotBlockState(pCompat);
-        for (var patternKey : Registries.DECORATED_POT_PATTERN.getKeys()) {
+        for (var patternKey : BuiltInRegistries.DECORATED_POT_PATTERN.registryKeySet()) {
             ResourceUtil.addDecoratedPotPatternModels(patternKey, p);
         }
 
@@ -157,9 +156,9 @@ public enum EBESetup {;
 
     public static void setupResourceProviders() {
         ModelLoadingPlugin.register(new DynamicModelProvidingPlugin(
-                Identifier.of("builtin", "chest_center"),
+                ResourceLocation.fromNamespaceAndPath("builtin", "chest_center"),
                 () -> new DynamicUnbakedModel(
-                        new Identifier[] {
+                        new ResourceLocation[] {
                                 ModelIdentifiers.CHEST_CENTER,
                                 ModelIdentifiers.CHEST_CENTER_TRUNK,
                                 ModelIdentifiers.CHRISTMAS_CHEST_CENTER,
@@ -170,9 +169,9 @@ public enum EBESetup {;
                 )
         ));
         ModelLoadingPlugin.register(new DynamicModelProvidingPlugin(
-                Identifier.of("builtin", "chest_left"),
+                ResourceLocation.fromNamespaceAndPath("builtin", "chest_left"),
                 () -> new DynamicUnbakedModel(
-                        new Identifier[] {
+                        new ResourceLocation[] {
                                 ModelIdentifiers.CHEST_LEFT,
                                 ModelIdentifiers.CHEST_LEFT_TRUNK,
                                 ModelIdentifiers.CHRISTMAS_CHEST_LEFT,
@@ -184,9 +183,9 @@ public enum EBESetup {;
         ));
 
         ModelLoadingPlugin.register(new DynamicModelProvidingPlugin(
-                Identifier.of("builtin", "chest_right"),
+                ResourceLocation.fromNamespaceAndPath("builtin", "chest_right"),
                 () -> new DynamicUnbakedModel(
-                        new Identifier[] {
+                        new ResourceLocation[] {
                                 ModelIdentifiers.CHEST_RIGHT,
                                 ModelIdentifiers.CHEST_RIGHT_TRUNK,
                                 ModelIdentifiers.CHRISTMAS_CHEST_RIGHT,
@@ -197,9 +196,9 @@ public enum EBESetup {;
                 )
         ));
         ModelLoadingPlugin.register(new DynamicModelProvidingPlugin(
-                Identifier.of("builtin", "trapped_chest_center"),
+                ResourceLocation.fromNamespaceAndPath("builtin", "trapped_chest_center"),
                 () -> new DynamicUnbakedModel(
-                        new Identifier[] {
+                        new ResourceLocation[] {
                                 ModelIdentifiers.TRAPPED_CHEST_CENTER,
                                 ModelIdentifiers.TRAPPED_CHEST_CENTER_TRUNK,
                                 ModelIdentifiers.CHRISTMAS_CHEST_CENTER,
@@ -210,9 +209,9 @@ public enum EBESetup {;
                 )
         ));
         ModelLoadingPlugin.register(new DynamicModelProvidingPlugin(
-                Identifier.of("builtin", "trapped_chest_left"),
+                ResourceLocation.fromNamespaceAndPath("builtin", "trapped_chest_left"),
                 () -> new DynamicUnbakedModel(
-                        new Identifier[] {
+                        new ResourceLocation[] {
                                 ModelIdentifiers.TRAPPED_CHEST_LEFT,
                                 ModelIdentifiers.TRAPPED_CHEST_LEFT_TRUNK,
                                 ModelIdentifiers.CHRISTMAS_CHEST_LEFT,
@@ -223,9 +222,9 @@ public enum EBESetup {;
                 )
         ));
         ModelLoadingPlugin.register(new DynamicModelProvidingPlugin(
-                Identifier.of("builtin", "trapped_chest_right"),
+                ResourceLocation.fromNamespaceAndPath("builtin", "trapped_chest_right"),
                 () -> new DynamicUnbakedModel(
-                        new Identifier[] {
+                        new ResourceLocation[] {
                                 ModelIdentifiers.TRAPPED_CHEST_RIGHT,
                                 ModelIdentifiers.TRAPPED_CHEST_RIGHT_TRUNK,
                                 ModelIdentifiers.CHRISTMAS_CHEST_RIGHT,
@@ -236,9 +235,9 @@ public enum EBESetup {;
                 )
         ));
         ModelLoadingPlugin.register(new DynamicModelProvidingPlugin(
-                Identifier.of("builtin", "ender_chest_center"),
+                ResourceLocation.fromNamespaceAndPath("builtin", "ender_chest_center"),
                 () -> new DynamicUnbakedModel(
-                        new Identifier[] {
+                        new ResourceLocation[] {
                                 ModelIdentifiers.ENDER_CHEST_CENTER,
                                 ModelIdentifiers.ENDER_CHEST_CENTER_TRUNK
                         },
@@ -248,9 +247,9 @@ public enum EBESetup {;
         ));
 
         ModelLoadingPlugin.register(new DynamicModelProvidingPlugin(
-                Identifier.of("builtin", "bell_between_walls"),
+                ResourceLocation.fromNamespaceAndPath("builtin", "bell_between_walls"),
                 () -> new DynamicUnbakedModel(
-                        new Identifier[] {
+                        new ResourceLocation[] {
                                 ModelIdentifiers.BELL_BETWEEN_WALLS_WITH_BELL,
                                 ModelIdentifiers.BELL_BETWEEN_WALLS
                         },
@@ -259,9 +258,9 @@ public enum EBESetup {;
                 )
         ));
         ModelLoadingPlugin.register(new DynamicModelProvidingPlugin(
-                Identifier.of("builtin", "bell_ceiling"),
+                ResourceLocation.fromNamespaceAndPath("builtin", "bell_ceiling"),
                 () -> new DynamicUnbakedModel(
-                        new Identifier[] {
+                        new ResourceLocation[] {
                                 ModelIdentifiers.BELL_CEILING_WITH_BELL,
                                 ModelIdentifiers.BELL_CEILING
                         },
@@ -270,9 +269,9 @@ public enum EBESetup {;
                 )
         ));
         ModelLoadingPlugin.register(new DynamicModelProvidingPlugin(
-                Identifier.of("builtin", "bell_floor"),
+                ResourceLocation.fromNamespaceAndPath("builtin", "bell_floor"),
                 () -> new DynamicUnbakedModel(
-                        new Identifier[] {
+                        new ResourceLocation[] {
                                 ModelIdentifiers.BELL_FLOOR_WITH_BELL,
                                 ModelIdentifiers.BELL_FLOOR
                         },
@@ -281,9 +280,9 @@ public enum EBESetup {;
                 )
         ));
         ModelLoadingPlugin.register(new DynamicModelProvidingPlugin(
-                Identifier.of("builtin", "bell_wall"),
+                ResourceLocation.fromNamespaceAndPath("builtin", "bell_wall"),
                 () -> new DynamicUnbakedModel(
-                        new Identifier[] {
+                        new ResourceLocation[] {
                                 ModelIdentifiers.BELL_WALL_WITH_BELL,
                                 ModelIdentifiers.BELL_WALL
                         },
@@ -293,9 +292,9 @@ public enum EBESetup {;
         ));
         for (DyeColor color : EBEUtil.DEFAULTED_DYE_COLORS) {
             ModelLoadingPlugin.register(new DynamicModelProvidingPlugin(
-                    Identifier.of("builtin", color != null ? color.getName()+"_shulker_box" : "shulker_box"),
+                    ResourceLocation.fromNamespaceAndPath("builtin", color != null ? color.getName()+"_shulker_box" : "shulker_box"),
                     () -> new DynamicUnbakedModel(
-                            new Identifier[] {
+                            new ResourceLocation[] {
                                     ModelIdentifiers.SHULKER_BOXES.get(color),
                                     ModelIdentifiers.SHULKER_BOX_BOTTOMS.get(color)
                             },
@@ -307,7 +306,7 @@ public enum EBESetup {;
 
         DecoratedPotModelSelector decoratedPotSelector = new DecoratedPotModelSelector();
         ModelLoadingPlugin.register(new DynamicModelProvidingPlugin(
-                Identifier.of("builtin", "decorated_pot"),
+                ResourceLocation.fromNamespaceAndPath("builtin", "decorated_pot"),
                 () -> new DynamicUnbakedModel(
                         decoratedPotSelector.createModelIDs(),
                         decoratedPotSelector,
@@ -317,18 +316,18 @@ public enum EBESetup {;
     }
 
     public static void setupChests() {
-        BlockRenderLayerMap.INSTANCE.putBlock(Blocks.CHEST, RenderLayer.getCutoutMipped());
-        BlockRenderLayerMap.INSTANCE.putBlock(Blocks.TRAPPED_CHEST, RenderLayer.getCutoutMipped());
-        BlockRenderLayerMap.INSTANCE.putBlock(Blocks.ENDER_CHEST, RenderLayer.getCutoutMipped());
+        BlockRenderLayerMap.INSTANCE.putBlock(Blocks.CHEST, RenderType.cutoutMipped());
+        BlockRenderLayerMap.INSTANCE.putBlock(Blocks.TRAPPED_CHEST, RenderType.cutoutMipped());
+        BlockRenderLayerMap.INSTANCE.putBlock(Blocks.ENDER_CHEST, RenderType.cutoutMipped());
 
         Function<BlockEntity, Integer> christmasChestSelector = entity -> {
             int os = DateUtil.isChristmas() ? 3 : 0;
-            ChestType type = entity.getCachedState().get(Properties.CHEST_TYPE);
+            ChestType type = entity.getBlockState().getValue(net.minecraft.world.level.block.ChestBlock.TYPE);
             return type == ChestType.RIGHT ? 2 + os : type == ChestType.LEFT ? 1 + os : os;
         };
         EnhancedBlockEntityRegistry.register(Blocks.CHEST, BlockEntityType.CHEST, BlockEntityRenderCondition.CHEST,
                 new ChestBlockEntityRendererOverride(() -> {
-                    FabricBakedModelManager manager =  MinecraftClient.getInstance().getBakedModelManager();
+                    var manager = Minecraft.getInstance().getModelManager();
                     return new BakedModel[] {
                             manager.getModel(ModelIdentifiers.CHEST_CENTER_LID),
                             manager.getModel(ModelIdentifiers.CHEST_LEFT_LID),
@@ -341,7 +340,7 @@ public enum EBESetup {;
         );
         EnhancedBlockEntityRegistry.register(Blocks.TRAPPED_CHEST, BlockEntityType.TRAPPED_CHEST, BlockEntityRenderCondition.CHEST,
                 new ChestBlockEntityRendererOverride(() -> {
-                    FabricBakedModelManager manager = MinecraftClient.getInstance().getBakedModelManager();
+                    var manager = Minecraft.getInstance().getModelManager();
                     return new BakedModel[] {
                             manager.getModel(ModelIdentifiers.TRAPPED_CHEST_CENTER_LID),
                             manager.getModel(ModelIdentifiers.TRAPPED_CHEST_LEFT_LID),
@@ -354,7 +353,7 @@ public enum EBESetup {;
         );
         EnhancedBlockEntityRegistry.register(Blocks.ENDER_CHEST, BlockEntityType.ENDER_CHEST, BlockEntityRenderCondition.CHEST,
                 new ChestBlockEntityRendererOverride(() -> {
-                    FabricBakedModelManager manager = MinecraftClient.getInstance().getBakedModelManager();
+                    var manager = Minecraft.getInstance().getModelManager();
                     return new BakedModel[] { manager.getModel(ModelIdentifiers.ENDER_CHEST_CENTER_LID) };
                 }, entity -> 0)
         );
@@ -397,7 +396,7 @@ public enum EBESetup {;
             EnhancedBlockEntityRegistry.register(sign, BlockEntityType.HANGING_SIGN, BlockEntityRenderCondition.SIGN,
                     new SignBlockEntityRendererOverride()
             );
-            BlockRenderLayerMap.INSTANCE.putBlock(sign, RenderLayer.getCutout());
+            BlockRenderLayerMap.INSTANCE.putBlock(sign, RenderType.cutout());
         }
     }
 
@@ -428,11 +427,11 @@ public enum EBESetup {;
 
     public static void setupShulkerBoxes() {
         for (DyeColor color : EBEUtil.DEFAULTED_DYE_COLORS) {
-            var block = ShulkerBoxBlock.get(color);
-            BlockRenderLayerMap.INSTANCE.putBlock(block, RenderLayer.getCutoutMipped());
+            var block = ShulkerBoxBlock.getBlockByColor(color);
+            BlockRenderLayerMap.INSTANCE.putBlock(block, RenderType.cutoutMipped());
             EnhancedBlockEntityRegistry.register(block, BlockEntityType.SHULKER_BOX, BlockEntityRenderCondition.SHULKER_BOX,
                     new ShulkerBoxBlockEntityRendererOverride((map) -> {
-                        var models =  MinecraftClient.getInstance().getBakedModelManager();
+                        var models = Minecraft.getInstance().getModelManager();
                         for (DyeColor dc : EBEUtil.DEFAULTED_DYE_COLORS) {
                             map.put(dc, models.getModel(ModelIdentifiers.SHULKER_BOX_LIDS.get(dc)));
                         }

--- a/src/main/java/foundationgames/enhancedblockentities/EnhancedBlockEntities.java
+++ b/src/main/java/foundationgames/enhancedblockentities/EnhancedBlockEntities.java
@@ -12,7 +12,7 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.render.item.property.bool.BooleanProperties;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -59,9 +59,9 @@ public final class EnhancedBlockEntities implements ClientModInitializer {
     public static void reload(ReloadType type) {
         load();
         if (type == ReloadType.WORLD) {
-            MinecraftClient.getInstance().worldRenderer.reload();
+            Minecraft.getInstance().levelRenderer.allChanged();
         } else if (type == ReloadType.RESOURCES) {
-            MinecraftClient.getInstance().reloadResources();
+            Minecraft.getInstance().reloadResourcePacks();
         }
     }
 

--- a/src/main/java/foundationgames/enhancedblockentities/EnhancedBlockEntityRegistry.java
+++ b/src/main/java/foundationgames/enhancedblockentities/EnhancedBlockEntityRegistry.java
@@ -1,10 +1,10 @@
 package foundationgames.enhancedblockentities;
 
+import com.mojang.datafixers.util.Pair;
 import foundationgames.enhancedblockentities.client.render.BlockEntityRenderCondition;
 import foundationgames.enhancedblockentities.client.render.BlockEntityRendererOverride;
-import net.minecraft.block.Block;
-import net.minecraft.block.entity.BlockEntityType;
-import net.minecraft.util.Pair;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 
 import java.util.HashMap;
 import java.util.HashSet;

--- a/src/main/java/foundationgames/enhancedblockentities/client/model/DynamicBakedModel.java
+++ b/src/main/java/foundationgames/enhancedblockentities/client/model/DynamicBakedModel.java
@@ -5,15 +5,15 @@ import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
 import net.fabricmc.fabric.api.renderer.v1.model.ModelHelper;
-import net.minecraft.block.BlockState;
-import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.render.model.BakedQuad;
-import net.minecraft.client.render.model.json.ModelTransformation;
-import net.minecraft.client.texture.Sprite;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.random.Random;
-import net.minecraft.world.BlockRenderView;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.block.model.ItemTransforms;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -43,7 +43,7 @@ public class DynamicBakedModel implements BakedModel, FabricBakedModel {
     }
 
     @Override
-    public void emitBlockQuads(QuadEmitter emitter, BlockRenderView view, BlockState state, BlockPos pos, Supplier<Random> rng, Predicate<@Nullable Direction> cullTest) {
+    public void emitBlockQuads(QuadEmitter emitter, BlockAndTintGetter view, BlockState state, BlockPos pos, Supplier<RandomSource> rng, Predicate<@Nullable Direction> cullTest) {
         RenderMaterial mat = null;
 
         var indices = this.activeModelIndices.get();
@@ -77,7 +77,7 @@ public class DynamicBakedModel implements BakedModel, FabricBakedModel {
     }
 
     @Override
-    public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction face, Random random) {
+    public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction face, RandomSource random) {
         return models[0].getQuads(state, face, random);
     }
 
@@ -97,13 +97,13 @@ public class DynamicBakedModel implements BakedModel, FabricBakedModel {
     }
 
     @Override
-    public Sprite getParticleSprite() {
-        return models[getSelector().getParticleModelIndex()].getParticleSprite();
+    public TextureAtlasSprite getParticleIcon() {
+        return models[getSelector().getParticleModelIndex()].getParticleIcon();
     }
 
     @Override
-    public ModelTransformation getTransformation() {
-        return null;
+    public ItemTransforms getTransforms() {
+        return ItemTransforms.NO_TRANSFORMS;
     }
 
     public BakedModel[] getModels() {

--- a/src/main/java/foundationgames/enhancedblockentities/client/model/DynamicModelProvidingPlugin.java
+++ b/src/main/java/foundationgames/enhancedblockentities/client/model/DynamicModelProvidingPlugin.java
@@ -2,17 +2,17 @@ package foundationgames.enhancedblockentities.client.model;
 
 import net.fabricmc.fabric.api.client.model.loading.v1.ModelLoadingPlugin;
 import net.fabricmc.fabric.api.client.model.loading.v1.ModelModifier;
-import net.minecraft.client.render.model.UnbakedModel;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.resources.model.UnbakedModel;
+import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Supplier;
 
 public class DynamicModelProvidingPlugin implements ModelLoadingPlugin, ModelModifier.OnLoad {
     private final Supplier<DynamicUnbakedModel> model;
-    private final Identifier id;
+    private final ResourceLocation id;
 
-    public DynamicModelProvidingPlugin(Identifier id, Supplier<DynamicUnbakedModel> model) {
+    public DynamicModelProvidingPlugin(ResourceLocation id, Supplier<DynamicUnbakedModel> model) {
         this.model = model;
         this.id = id;
     }

--- a/src/main/java/foundationgames/enhancedblockentities/client/model/DynamicUnbakedModel.java
+++ b/src/main/java/foundationgames/enhancedblockentities/client/model/DynamicUnbakedModel.java
@@ -1,20 +1,20 @@
 package foundationgames.enhancedblockentities.client.model;
 
-import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.render.model.Baker;
-import net.minecraft.client.render.model.ModelBakeSettings;
-import net.minecraft.client.render.model.ModelTextures;
-import net.minecraft.client.render.model.UnbakedModel;
-import net.minecraft.client.render.model.json.ModelTransformation;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.resources.model.ModelBaker;
+import net.minecraft.client.resources.model.ModelState;
+import net.minecraft.client.resources.model.Material;
+import net.minecraft.client.resources.model.UnbakedModel;
+import net.minecraft.client.renderer.block.model.ItemTransforms;
+import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
 
 public class DynamicUnbakedModel implements UnbakedModel {
-    private final Identifier[] models;
+    private final ResourceLocation[] models;
     private final ModelSelector selector;
     private final DynamicModelEffects effects;
 
-    public DynamicUnbakedModel(Identifier[] models, ModelSelector selector, DynamicModelEffects effects) {
+    public DynamicUnbakedModel(ResourceLocation[] models, ModelSelector selector, DynamicModelEffects effects) {
         this.models = models;
         this.selector = selector;
         this.effects = effects;
@@ -22,14 +22,14 @@ public class DynamicUnbakedModel implements UnbakedModel {
 
     @Override
     public void resolve(Resolver resolver) {
-        for (Identifier modelId : models) {
+        for (ResourceLocation modelId : models) {
             if(modelId == null) continue;
             resolver.resolve(modelId);
         }
     }
 
     @Override
-    public @Nullable BakedModel bake(ModelTextures textures, Baker baker, ModelBakeSettings settings, boolean ambientOcclusion, boolean isSideLit, ModelTransformation transformation) {
+    public @Nullable BakedModel bake(ModelBaker baker, java.util.function.Function<Material, net.minecraft.client.renderer.texture.TextureAtlasSprite> spriteGetter, ModelState settings) {
         BakedModel[] baked = new BakedModel[models.length];
         for (int i = 0; i < models.length; i++) {
             baked[i] = baker.bake(models[i], settings);

--- a/src/main/java/foundationgames/enhancedblockentities/client/model/ModelIdentifiers.java
+++ b/src/main/java/foundationgames/enhancedblockentities/client/model/ModelIdentifiers.java
@@ -4,12 +4,12 @@ import foundationgames.enhancedblockentities.EnhancedBlockEntities;
 import foundationgames.enhancedblockentities.config.EBEConfig;
 import foundationgames.enhancedblockentities.util.EBEUtil;
 import net.fabricmc.fabric.api.client.model.loading.v1.ModelLoadingPlugin;
-import net.minecraft.block.DecoratedPotPattern;
-import net.minecraft.registry.Registries;
-import net.minecraft.registry.RegistryKey;
-import net.minecraft.util.DyeColor;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.math.Direction;
+import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.level.block.DecoratedPotPattern;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -18,65 +18,65 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 public final class ModelIdentifiers implements ModelLoadingPlugin {
-    private static final Map<Predicate<EBEConfig>, Set<Identifier>> modelLoaders = new HashMap<>();
+    private static final Map<Predicate<EBEConfig>, Set<ResourceLocation>> modelLoaders = new HashMap<>();
 
     public static final Predicate<EBEConfig> CHEST_PREDICATE = c -> c.renderEnhancedChests;
     public static final Predicate<EBEConfig> BELL_PREDICATE = c -> c.renderEnhancedBells;
     public static final Predicate<EBEConfig> SHULKER_BOX_PREDICATE = c -> c.renderEnhancedShulkerBoxes;
     public static final Predicate<EBEConfig> DECORATED_POT_PREDICATE = c -> c.renderEnhancedDecoratedPots;
 
-    public static final Identifier CHEST_CENTER = of("block/chest_center", CHEST_PREDICATE);
-    public static final Identifier CHEST_CENTER_TRUNK = of("block/chest_center_trunk", CHEST_PREDICATE);
-    public static final Identifier CHEST_CENTER_LID = of("block/chest_center_lid", CHEST_PREDICATE);
-    public static final Identifier CHEST_LEFT = of("block/chest_left", CHEST_PREDICATE);
-    public static final Identifier CHEST_LEFT_TRUNK = of("block/chest_left_trunk", CHEST_PREDICATE);
-    public static final Identifier CHEST_LEFT_LID = of("block/chest_left_lid", CHEST_PREDICATE);
-    public static final Identifier CHEST_RIGHT = of("block/chest_right", CHEST_PREDICATE);
-    public static final Identifier CHEST_RIGHT_TRUNK = of("block/chest_right_trunk", CHEST_PREDICATE);
-    public static final Identifier CHEST_RIGHT_LID = of("block/chest_right_lid", CHEST_PREDICATE);
+    public static final ResourceLocation CHEST_CENTER = of("block/chest_center", CHEST_PREDICATE);
+    public static final ResourceLocation CHEST_CENTER_TRUNK = of("block/chest_center_trunk", CHEST_PREDICATE);
+    public static final ResourceLocation CHEST_CENTER_LID = of("block/chest_center_lid", CHEST_PREDICATE);
+    public static final ResourceLocation CHEST_LEFT = of("block/chest_left", CHEST_PREDICATE);
+    public static final ResourceLocation CHEST_LEFT_TRUNK = of("block/chest_left_trunk", CHEST_PREDICATE);
+    public static final ResourceLocation CHEST_LEFT_LID = of("block/chest_left_lid", CHEST_PREDICATE);
+    public static final ResourceLocation CHEST_RIGHT = of("block/chest_right", CHEST_PREDICATE);
+    public static final ResourceLocation CHEST_RIGHT_TRUNK = of("block/chest_right_trunk", CHEST_PREDICATE);
+    public static final ResourceLocation CHEST_RIGHT_LID = of("block/chest_right_lid", CHEST_PREDICATE);
 
-    public static final Identifier TRAPPED_CHEST_CENTER = of("block/trapped_chest_center", CHEST_PREDICATE);
-    public static final Identifier TRAPPED_CHEST_CENTER_TRUNK = of("block/trapped_chest_center_trunk", CHEST_PREDICATE);
-    public static final Identifier TRAPPED_CHEST_CENTER_LID = of("block/trapped_chest_center_lid", CHEST_PREDICATE);
-    public static final Identifier TRAPPED_CHEST_LEFT = of("block/trapped_chest_left", CHEST_PREDICATE);
-    public static final Identifier TRAPPED_CHEST_LEFT_TRUNK = of("block/trapped_chest_left_trunk", CHEST_PREDICATE);
-    public static final Identifier TRAPPED_CHEST_LEFT_LID = of("block/trapped_chest_left_lid", CHEST_PREDICATE);
-    public static final Identifier TRAPPED_CHEST_RIGHT = of("block/trapped_chest_right", CHEST_PREDICATE);
-    public static final Identifier TRAPPED_CHEST_RIGHT_TRUNK = of("block/trapped_chest_right_trunk", CHEST_PREDICATE);
-    public static final Identifier TRAPPED_CHEST_RIGHT_LID = of("block/trapped_chest_right_lid", CHEST_PREDICATE);
+    public static final ResourceLocation TRAPPED_CHEST_CENTER = of("block/trapped_chest_center", CHEST_PREDICATE);
+    public static final ResourceLocation TRAPPED_CHEST_CENTER_TRUNK = of("block/trapped_chest_center_trunk", CHEST_PREDICATE);
+    public static final ResourceLocation TRAPPED_CHEST_CENTER_LID = of("block/trapped_chest_center_lid", CHEST_PREDICATE);
+    public static final ResourceLocation TRAPPED_CHEST_LEFT = of("block/trapped_chest_left", CHEST_PREDICATE);
+    public static final ResourceLocation TRAPPED_CHEST_LEFT_TRUNK = of("block/trapped_chest_left_trunk", CHEST_PREDICATE);
+    public static final ResourceLocation TRAPPED_CHEST_LEFT_LID = of("block/trapped_chest_left_lid", CHEST_PREDICATE);
+    public static final ResourceLocation TRAPPED_CHEST_RIGHT = of("block/trapped_chest_right", CHEST_PREDICATE);
+    public static final ResourceLocation TRAPPED_CHEST_RIGHT_TRUNK = of("block/trapped_chest_right_trunk", CHEST_PREDICATE);
+    public static final ResourceLocation TRAPPED_CHEST_RIGHT_LID = of("block/trapped_chest_right_lid", CHEST_PREDICATE);
 
-    public static final Identifier CHRISTMAS_CHEST_CENTER = of("block/christmas_chest_center", CHEST_PREDICATE);
-    public static final Identifier CHRISTMAS_CHEST_CENTER_TRUNK = of("block/christmas_chest_center_trunk", CHEST_PREDICATE);
-    public static final Identifier CHRISTMAS_CHEST_CENTER_LID = of("block/christmas_chest_center_lid", CHEST_PREDICATE);
-    public static final Identifier CHRISTMAS_CHEST_LEFT = of("block/christmas_chest_left", CHEST_PREDICATE);
-    public static final Identifier CHRISTMAS_CHEST_LEFT_TRUNK = of("block/christmas_chest_left_trunk", CHEST_PREDICATE);
-    public static final Identifier CHRISTMAS_CHEST_LEFT_LID = of("block/christmas_chest_left_lid", CHEST_PREDICATE);
-    public static final Identifier CHRISTMAS_CHEST_RIGHT = of("block/christmas_chest_right", CHEST_PREDICATE);
-    public static final Identifier CHRISTMAS_CHEST_RIGHT_TRUNK = of("block/christmas_chest_right_trunk", CHEST_PREDICATE);
-    public static final Identifier CHRISTMAS_CHEST_RIGHT_LID = of("block/christmas_chest_right_lid", CHEST_PREDICATE);
+    public static final ResourceLocation CHRISTMAS_CHEST_CENTER = of("block/christmas_chest_center", CHEST_PREDICATE);
+    public static final ResourceLocation CHRISTMAS_CHEST_CENTER_TRUNK = of("block/christmas_chest_center_trunk", CHEST_PREDICATE);
+    public static final ResourceLocation CHRISTMAS_CHEST_CENTER_LID = of("block/christmas_chest_center_lid", CHEST_PREDICATE);
+    public static final ResourceLocation CHRISTMAS_CHEST_LEFT = of("block/christmas_chest_left", CHEST_PREDICATE);
+    public static final ResourceLocation CHRISTMAS_CHEST_LEFT_TRUNK = of("block/christmas_chest_left_trunk", CHEST_PREDICATE);
+    public static final ResourceLocation CHRISTMAS_CHEST_LEFT_LID = of("block/christmas_chest_left_lid", CHEST_PREDICATE);
+    public static final ResourceLocation CHRISTMAS_CHEST_RIGHT = of("block/christmas_chest_right", CHEST_PREDICATE);
+    public static final ResourceLocation CHRISTMAS_CHEST_RIGHT_TRUNK = of("block/christmas_chest_right_trunk", CHEST_PREDICATE);
+    public static final ResourceLocation CHRISTMAS_CHEST_RIGHT_LID = of("block/christmas_chest_right_lid", CHEST_PREDICATE);
 
-    public static final Identifier ENDER_CHEST_CENTER = of("block/ender_chest_center", CHEST_PREDICATE);
-    public static final Identifier ENDER_CHEST_CENTER_TRUNK = of("block/ender_chest_center_trunk", CHEST_PREDICATE);
-    public static final Identifier ENDER_CHEST_CENTER_LID = of("block/ender_chest_center_lid", CHEST_PREDICATE);
+    public static final ResourceLocation ENDER_CHEST_CENTER = of("block/ender_chest_center", CHEST_PREDICATE);
+    public static final ResourceLocation ENDER_CHEST_CENTER_TRUNK = of("block/ender_chest_center_trunk", CHEST_PREDICATE);
+    public static final ResourceLocation ENDER_CHEST_CENTER_LID = of("block/ender_chest_center_lid", CHEST_PREDICATE);
 
-    public static final Identifier BELL_BETWEEN_WALLS = of("block/bell_between_walls", BELL_PREDICATE);
-    public static final Identifier BELL_CEILING = of("block/bell_ceiling", BELL_PREDICATE);
-    public static final Identifier BELL_FLOOR = of("block/bell_floor", BELL_PREDICATE);
-    public static final Identifier BELL_WALL = of("block/bell_wall", BELL_PREDICATE);
-    public static final Identifier BELL_BETWEEN_WALLS_WITH_BELL = of("block/bell_between_walls_with_bell", BELL_PREDICATE);
-    public static final Identifier BELL_CEILING_WITH_BELL = of("block/bell_ceiling_with_bell", BELL_PREDICATE);
-    public static final Identifier BELL_FLOOR_WITH_BELL = of("block/bell_floor_with_bell", BELL_PREDICATE);
-    public static final Identifier BELL_WALL_WITH_BELL = of("block/bell_wall_with_bell", BELL_PREDICATE);
-    public static final Identifier BELL_BODY = of("block/bell_body", BELL_PREDICATE);
+    public static final ResourceLocation BELL_BETWEEN_WALLS = of("block/bell_between_walls", BELL_PREDICATE);
+    public static final ResourceLocation BELL_CEILING = of("block/bell_ceiling", BELL_PREDICATE);
+    public static final ResourceLocation BELL_FLOOR = of("block/bell_floor", BELL_PREDICATE);
+    public static final ResourceLocation BELL_WALL = of("block/bell_wall", BELL_PREDICATE);
+    public static final ResourceLocation BELL_BETWEEN_WALLS_WITH_BELL = of("block/bell_between_walls_with_bell", BELL_PREDICATE);
+    public static final ResourceLocation BELL_CEILING_WITH_BELL = of("block/bell_ceiling_with_bell", BELL_PREDICATE);
+    public static final ResourceLocation BELL_FLOOR_WITH_BELL = of("block/bell_floor_with_bell", BELL_PREDICATE);
+    public static final ResourceLocation BELL_WALL_WITH_BELL = of("block/bell_wall_with_bell", BELL_PREDICATE);
+    public static final ResourceLocation BELL_BODY = of("block/bell_body", BELL_PREDICATE);
 
-    public static final Identifier DECORATED_POT_BASE = of("block/decorated_pot_base", DECORATED_POT_PREDICATE);
-    public static final Identifier DECORATED_POT_SHAKING = of("block/decorated_pot_shaking", DECORATED_POT_PREDICATE);
+    public static final ResourceLocation DECORATED_POT_BASE = of("block/decorated_pot_base", DECORATED_POT_PREDICATE);
+    public static final ResourceLocation DECORATED_POT_SHAKING = of("block/decorated_pot_shaking", DECORATED_POT_PREDICATE);
 
-    public static final Map<DyeColor, Identifier> SHULKER_BOXES = new HashMap<>();
-    public static final Map<DyeColor, Identifier> SHULKER_BOX_BOTTOMS = new HashMap<>();
-    public static final Map<DyeColor, Identifier> SHULKER_BOX_LIDS = new HashMap<>();
+    public static final Map<DyeColor, ResourceLocation> SHULKER_BOXES = new HashMap<>();
+    public static final Map<DyeColor, ResourceLocation> SHULKER_BOX_BOTTOMS = new HashMap<>();
+    public static final Map<DyeColor, ResourceLocation> SHULKER_BOX_LIDS = new HashMap<>();
 
-    public static final Map<RegistryKey<DecoratedPotPattern>, Identifier[]> POTTERY_PATTERNS = new HashMap<>();
+    public static final Map<ResourceKey<DecoratedPotPattern>, ResourceLocation[]> POTTERY_PATTERNS = new HashMap<>();
 
     static {
         for (DyeColor color : EBEUtil.DEFAULTED_DYE_COLORS) {
@@ -99,9 +99,9 @@ public final class ModelIdentifiers implements ModelLoadingPlugin {
         // The order decorated pots store patterns per face
         Direction[] orderedHorizontalDirs = new Direction[] {Direction.NORTH, Direction.WEST, Direction.EAST, Direction.SOUTH};
 
-        for (var patternKey : Registries.DECORATED_POT_PATTERN.getKeys()) {
-            var pattern = patternKey.getValue().getPath();
-            var ids = new Identifier[orderedHorizontalDirs.length];;
+        for (var patternKey : BuiltInRegistries.DECORATED_POT_PATTERN.registryKeySet()) {
+            var pattern = patternKey.location().getPath();
+            var ids = new ResourceLocation[orderedHorizontalDirs.length];
 
             for (int i = 0; i < 4; i++) {
                 ids[i] = of("block/" + pattern + "_" + orderedHorizontalDirs[i].getName(),
@@ -112,10 +112,10 @@ public final class ModelIdentifiers implements ModelLoadingPlugin {
         }
     }
 
-    private static Identifier of(String id, Predicate<EBEConfig> condition) {
-        Identifier idf = Identifier.of(id);
-        modelLoaders.computeIfAbsent(condition, k -> new HashSet<>()).add(idf);
-        return idf;
+    private static ResourceLocation of(String id, Predicate<EBEConfig> condition) {
+        ResourceLocation rl = ResourceLocation.parse(id);
+        modelLoaders.computeIfAbsent(condition, k -> new HashSet<>()).add(rl);
+        return rl;
     }
 
     @Override

--- a/src/main/java/foundationgames/enhancedblockentities/client/model/ModelSelector.java
+++ b/src/main/java/foundationgames/enhancedblockentities/client/model/ModelSelector.java
@@ -2,10 +2,10 @@ package foundationgames.enhancedblockentities.client.model;
 
 import foundationgames.enhancedblockentities.util.DateUtil;
 import foundationgames.enhancedblockentities.util.duck.AppearanceStateHolder;
-import net.minecraft.block.BlockState;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.random.Random;
-import net.minecraft.world.BlockRenderView;
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +16,7 @@ public abstract class ModelSelector {
 
     public static final ModelSelector STATE_HOLDER_SELECTOR = new ModelSelector() {
         @Override
-        public void writeModelIndices(BlockRenderView view, BlockState state, BlockPos pos, Supplier<Random> rand, int[] indices) {
+        public void writeModelIndices(BlockAndTintGetter view, BlockState state, BlockPos pos, Supplier<RandomSource> rand, int[] indices) {
             if (view.getBlockEntity(pos) instanceof AppearanceStateHolder stateHolder) {
                 indices[0] = stateHolder.getModelState();
                 return;
@@ -34,7 +34,7 @@ public abstract class ModelSelector {
         }
 
         @Override
-        public void writeModelIndices(BlockRenderView view, BlockState state, BlockPos pos, Supplier<Random> rand, int[] indices) {
+        public void writeModelIndices(BlockAndTintGetter view, BlockState state, BlockPos pos, Supplier<RandomSource> rand, int[] indices) {
             if (view.getBlockEntity(pos) instanceof AppearanceStateHolder stateHolder) {
                 indices[0] = stateHolder.getModelState() + this.getParticleModelIndex();
                 return;
@@ -51,7 +51,7 @@ public abstract class ModelSelector {
         return 0;
     }
 
-    public abstract void writeModelIndices(BlockRenderView view, BlockState state, BlockPos pos, Supplier<Random> rand, int[] indices);
+    public abstract void writeModelIndices(BlockAndTintGetter view, BlockState state, BlockPos pos, Supplier<RandomSource> rand, int[] indices);
 
     public final int id;
     public final int displayedModelCount;

--- a/src/main/java/foundationgames/enhancedblockentities/client/model/item/EBEIsChristmasProperty.java
+++ b/src/main/java/foundationgames/enhancedblockentities/client/model/item/EBEIsChristmasProperty.java
@@ -2,23 +2,23 @@ package foundationgames.enhancedblockentities.client.model.item;
 
 import com.mojang.serialization.MapCodec;
 import foundationgames.enhancedblockentities.util.DateUtil;
-import net.minecraft.client.render.item.property.bool.BooleanProperty;
-import net.minecraft.client.world.ClientWorld;
-import net.minecraft.entity.LivingEntity;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.ModelTransformationMode;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.item.properties.bool.BooleanModelProperty;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemDisplayContext;
+import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
-public record EBEIsChristmasProperty() implements BooleanProperty {
+public record EBEIsChristmasProperty() implements BooleanModelProperty {
     public static final MapCodec<EBEIsChristmasProperty> CODEC = MapCodec.unit(new EBEIsChristmasProperty());
 
     @Override
-    public boolean getValue(ItemStack stack, @Nullable ClientWorld world, @Nullable LivingEntity user, int seed, ModelTransformationMode modelTransformationMode) {
+    public boolean get(ItemStack stack, @Nullable ClientLevel world, @Nullable LivingEntity user, int seed, ItemDisplayContext displayContext) {
         return DateUtil.isChristmas();
     }
 
     @Override
-    public MapCodec<EBEIsChristmasProperty> getCodec() {
+    public MapCodec<EBEIsChristmasProperty> type() {
         return CODEC;
     }
 }

--- a/src/main/java/foundationgames/enhancedblockentities/client/model/misc/DecoratedPotModelSelector.java
+++ b/src/main/java/foundationgames/enhancedblockentities/client/model/misc/DecoratedPotModelSelector.java
@@ -3,18 +3,18 @@ package foundationgames.enhancedblockentities.client.model.misc;
 import foundationgames.enhancedblockentities.client.model.ModelIdentifiers;
 import foundationgames.enhancedblockentities.client.model.ModelSelector;
 import foundationgames.enhancedblockentities.util.duck.AppearanceStateHolder;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.DecoratedPotPattern;
-import net.minecraft.block.DecoratedPotPatterns;
-import net.minecraft.block.entity.DecoratedPotBlockEntity;
-import net.minecraft.item.Item;
-import net.minecraft.registry.Registries;
-import net.minecraft.registry.RegistryKey;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.random.Random;
-import net.minecraft.world.BlockRenderView;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.block.DecoratedPotPattern;
+import net.minecraft.world.level.block.DecoratedPotPatterns;
+import net.minecraft.world.level.block.entity.DecoratedPotBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,18 +28,18 @@ public class DecoratedPotModelSelector extends ModelSelector {
     public static final int IDX_EMPTY = 0;
     public static final int IDX_BASE_POT = 1;
 
-    private final List<RegistryKey<DecoratedPotPattern>> potteryPatterns;
+    private final List<ResourceKey<DecoratedPotPattern>> potteryPatterns;
 
     public DecoratedPotModelSelector() {
         super(5);
 
-        this.potteryPatterns = new ArrayList<>(Registries.DECORATED_POT_PATTERN.getKeys());
+        this.potteryPatterns = new ArrayList<>(BuiltInRegistries.DECORATED_POT_PATTERN.registryKeySet());
     }
 
-    public Identifier[] createModelIDs() {
+    public ResourceLocation[] createModelIDs() {
         ModelIdentifiers.refreshPotteryPatterns();
 
-        var ids = new Identifier[BUILTIN_MODEL_COUNT + potteryPatterns.size() * 4];
+        var ids = new ResourceLocation[BUILTIN_MODEL_COUNT + potteryPatterns.size() * 4];
         ids[IDX_EMPTY] = ModelIdentifiers.DECORATED_POT_SHAKING;
         ids[IDX_BASE_POT] = ModelIdentifiers.DECORATED_POT_BASE;
 
@@ -56,7 +56,7 @@ public class DecoratedPotModelSelector extends ModelSelector {
     }
 
     @Override
-    public void writeModelIndices(BlockRenderView view, BlockState state, BlockPos pos, Supplier<Random> rand, int[] indices) {
+    public void writeModelIndices(BlockAndTintGetter view, BlockState state, BlockPos pos, Supplier<RandomSource> rand, int[] indices) {
         final int patternCount = potteryPatterns.size();
 
         indices[0] = IDX_BASE_POT;
@@ -82,6 +82,6 @@ public class DecoratedPotModelSelector extends ModelSelector {
     }
 
     private int getPatternIndex(Optional<Item> sherd, int max) {
-        return MathHelper.clamp(this.potteryPatterns.indexOf(sherd.map(DecoratedPotPatterns::fromSherd).orElse(DecoratedPotPatterns.BLANK)), 0, max - 1);
+        return Mth.clamp(this.potteryPatterns.indexOf(sherd.map(DecoratedPotPatterns::fromSherd).orElse(DecoratedPotPatterns.BLANK)), 0, max - 1);
     }
 }

--- a/src/main/java/foundationgames/enhancedblockentities/client/render/BlockEntityRenderCondition.java
+++ b/src/main/java/foundationgames/enhancedblockentities/client/render/BlockEntityRenderCondition.java
@@ -4,9 +4,9 @@ import foundationgames.enhancedblockentities.EnhancedBlockEntities;
 import foundationgames.enhancedblockentities.config.EBEConfig;
 import foundationgames.enhancedblockentities.mixin.AbstractSignBlockEntityRenderAccessor;
 import foundationgames.enhancedblockentities.util.duck.AppearanceStateHolder;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.util.math.Vec3d;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.level.block.entity.BlockEntity;
 
 @FunctionalInterface
 public interface BlockEntityRenderCondition {
@@ -28,22 +28,22 @@ public interface BlockEntityRenderCondition {
         if (config.signTextRendering.equals("all")) {
             return true;
         }
-        double playerDistance = MinecraftClient.getInstance().player.getBlockPos().getSquaredDistance(entity.getPos());
+        double playerDistance = Minecraft.getInstance().player.blockPosition().distSqr(entity.getBlockPos());
         if (config.signTextRendering.equals("smart")) {
             SignRenderManager.renderedSigns++;
             return playerDistance < 80 + Math.max(0, 580 - (SignRenderManager.getRenderedSignAmount() * 0.7));
         }
         double dist = AbstractSignBlockEntityRenderAccessor.enhanced_bes$getRenderDistance();
-        Vec3d blockPos = Vec3d.ofCenter(entity.getPos());
-        Vec3d playerPos = MinecraftClient.getInstance().player.getPos();
+        Vec3 blockPos = Vec3.atCenterOf(entity.getBlockPos());
+        Vec3 playerPos = Minecraft.getInstance().player.position();
         if (config.signTextRendering.equals("most")) {
-            return blockPos.isInRange(playerPos, dist * 0.6);
+            return blockPos.closerThan(playerPos, dist * 0.6);
         }
         if (config.signTextRendering.equals("some")) {
-            return blockPos.isInRange(playerPos, dist * 0.3);
+            return blockPos.closerThan(playerPos, dist * 0.3);
         }
         if (config.signTextRendering.equals("few")) {
-            return blockPos.isInRange(playerPos, dist * 0.15);
+            return blockPos.closerThan(playerPos, dist * 0.15);
         }
         return false;
     };

--- a/src/main/java/foundationgames/enhancedblockentities/client/render/BlockEntityRendererOverride.java
+++ b/src/main/java/foundationgames/enhancedblockentities/client/render/BlockEntityRendererOverride.java
@@ -1,22 +1,22 @@
 package foundationgames.enhancedblockentities.client.render;
 
 import foundationgames.enhancedblockentities.event.EBEEvents;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.client.render.VertexConsumerProvider;
-import net.minecraft.client.render.block.entity.BlockEntityRenderer;
-import net.minecraft.client.util.math.MatrixStack;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
+import net.minecraft.world.level.block.entity.BlockEntity;
 
 public abstract class BlockEntityRendererOverride {
     public static final BlockEntityRendererOverride NO_OP = new BlockEntityRendererOverride() {
         @Override
-        public void render(BlockEntityRenderer<BlockEntity> renderer, BlockEntity blockEntity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay) {}
+        public void render(BlockEntityRenderer<BlockEntity> renderer, BlockEntity blockEntity, float tickDelta, PoseStack matrices, MultiBufferSource vertexConsumers, int light, int overlay) {}
     };
 
     public BlockEntityRendererOverride() {
         EBEEvents.RESOURCE_RELOAD.register(this::onModelsReload);
     }
 
-    public abstract void render(BlockEntityRenderer<BlockEntity> renderer, BlockEntity blockEntity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay);
+    public abstract void render(BlockEntityRenderer<BlockEntity> renderer, BlockEntity blockEntity, float tickDelta, PoseStack matrices, MultiBufferSource vertexConsumers, int light, int overlay);
 
     public void onModelsReload() {}
 

--- a/src/main/java/foundationgames/enhancedblockentities/client/render/entity/BellBlockEntityRendererOverride.java
+++ b/src/main/java/foundationgames/enhancedblockentities/client/render/entity/BellBlockEntityRendererOverride.java
@@ -3,29 +3,29 @@ package foundationgames.enhancedblockentities.client.render.entity;
 import foundationgames.enhancedblockentities.client.model.ModelIdentifiers;
 import foundationgames.enhancedblockentities.client.render.BlockEntityRendererOverride;
 import foundationgames.enhancedblockentities.util.EBEUtil;
-import net.minecraft.block.entity.BellBlockEntity;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.render.VertexConsumerProvider;
-import net.minecraft.client.render.block.entity.BlockEntityRenderer;
-import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.RotationAxis;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.Direction;
+import net.minecraft.util.Mth;
+import com.mojang.math.Axis;
+import net.minecraft.world.level.block.entity.BellBlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntity;
 
 public class BellBlockEntityRendererOverride extends BlockEntityRendererOverride {
     private BakedModel bellModel = null;
 
     @Override
-    public void render(BlockEntityRenderer<BlockEntity> renderer, BlockEntity blockEntity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay) {
+    public void render(BlockEntityRenderer<BlockEntity> renderer, BlockEntity blockEntity, float tickDelta, PoseStack matrices, MultiBufferSource vertexConsumers, int light, int overlay) {
         if (bellModel == null) bellModel = getBellModel();
         if (bellModel != null && blockEntity instanceof BellBlockEntity self) {
             float ringTicks = (float)self.ringTicks + tickDelta;
             float bellPitch = 0.0F;
             float bellRoll = 0.0F;
             if (self.ringing) {
-                float swingAngle = MathHelper.sin(ringTicks / (float)Math.PI) / (4.0F + ringTicks / 3.0F);
+                float swingAngle = Mth.sin(ringTicks / (float)Math.PI) / (4.0F + ringTicks / 3.0F);
                 if (self.lastSideHit == Direction.NORTH) {
                     bellPitch = -swingAngle;
                 } else if (self.lastSideHit == Direction.SOUTH) {
@@ -36,19 +36,19 @@ public class BellBlockEntityRendererOverride extends BlockEntityRendererOverride
                     bellRoll = swingAngle;
                 }
             }
-            matrices.push();
+            matrices.pushPose();
             matrices.translate(8f/16, 12f/16, 8f/16);
-            matrices.multiply(RotationAxis.POSITIVE_X.rotation(bellPitch));
-            matrices.multiply(RotationAxis.POSITIVE_Z.rotation(bellRoll));
+            matrices.mulPose(Axis.XP.rotation(bellPitch));
+            matrices.mulPose(Axis.ZP.rotation(bellRoll));
             matrices.translate(-8f/16, -12f/16, -8f/16);
-            EBEUtil.renderBakedModel(vertexConsumers, blockEntity.getCachedState(), matrices, bellModel, light, overlay);
+            EBEUtil.renderBakedModel(vertexConsumers, blockEntity.getBlockState(), matrices, bellModel, light, overlay);
 
-            matrices.pop();
+            matrices.popPose();
         }
     }
 
     private BakedModel getBellModel() {
-        return MinecraftClient.getInstance().getBakedModelManager().getModel(ModelIdentifiers.BELL_BODY);
+        return Minecraft.getInstance().getModelManager().getModel(ModelIdentifiers.BELL_BODY);
     }
 
     @Override

--- a/src/main/java/foundationgames/enhancedblockentities/client/render/entity/ChestBlockEntityRendererOverride.java
+++ b/src/main/java/foundationgames/enhancedblockentities/client/render/entity/ChestBlockEntityRendererOverride.java
@@ -2,18 +2,18 @@ package foundationgames.enhancedblockentities.client.render.entity;
 
 import foundationgames.enhancedblockentities.client.render.BlockEntityRendererOverride;
 import foundationgames.enhancedblockentities.util.EBEUtil;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.ChestBlock;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.block.entity.LidOpenable;
-import net.minecraft.block.enums.ChestType;
-import net.minecraft.client.render.VertexConsumerProvider;
-import net.minecraft.client.render.block.entity.BlockEntityRenderer;
-import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.RotationAxis;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import com.mojang.math.Axis;
+import net.minecraft.world.level.block.ChestBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.LidBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.ChestType;
 
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -23,52 +23,54 @@ public class ChestBlockEntityRendererOverride extends BlockEntityRendererOverrid
     private final Supplier<BakedModel[]> modelGetter;
     private final Function<BlockEntity, Integer> modelSelector;
 
+    // LidOpenable was renamed to LidBlockEntity in Mojang mappings
+
     public ChestBlockEntityRendererOverride(Supplier<BakedModel[]> modelGetter, Function<BlockEntity, Integer> modelSelector) {
         this.modelGetter = modelGetter;
         this.modelSelector = modelSelector;
     }
 
     @Override
-    public void render(BlockEntityRenderer<BlockEntity> renderer, BlockEntity blockEntity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay) {
+    public void render(BlockEntityRenderer<BlockEntity> renderer, BlockEntity blockEntity, float tickDelta, PoseStack matrices, MultiBufferSource vertexConsumers, int light, int overlay) {
         if (models == null) models = modelGetter.get();
-        if (blockEntity instanceof LidOpenable) {
-            matrices.push();
+        if (blockEntity instanceof LidBlockEntity) {
+            matrices.pushPose();
 
-            LidOpenable chest = getLidAnimationHolder(blockEntity, tickDelta);
+            LidBlockEntity chest = getLidAnimationHolder(blockEntity, tickDelta);
             matrices.translate(0.5f, 0, 0.5f);
-            Direction dir = blockEntity.getCachedState().get(ChestBlock.FACING);
-            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180 - EBEUtil.angle(dir)));
+            Direction dir = blockEntity.getBlockState().getValue(ChestBlock.FACING);
+            matrices.mulPose(Axis.YP.rotationDegrees(180 - EBEUtil.angle(dir)));
             matrices.translate(-0.5f, 0, -0.5f);
             float yPiv = 9f / 16;
             float zPiv = 15f / 16;
             matrices.translate(0, yPiv, zPiv);
-            float rot = chest.getAnimationProgress(tickDelta);
+            float rot = chest.getOpenNess(tickDelta);
             rot = 1f - rot;
             rot = 1f - (rot * rot * rot);
-            matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(rot * 90));
+            matrices.mulPose(Axis.XP.rotationDegrees(rot * 90));
             matrices.translate(0, -yPiv, -zPiv);
-            EBEUtil.renderBakedModel(vertexConsumers, blockEntity.getCachedState(), matrices, models[modelSelector.apply(blockEntity)], light, overlay);
+            EBEUtil.renderBakedModel(vertexConsumers, blockEntity.getBlockState(), matrices, models[modelSelector.apply(blockEntity)], light, overlay);
 
-            matrices.pop();
+            matrices.popPose();
         }
     }
 
-    public static LidOpenable getLidAnimationHolder(BlockEntity blockEntity, float tickDelta) {
-        LidOpenable chest = (LidOpenable)blockEntity;
+    public static LidBlockEntity getLidAnimationHolder(BlockEntity blockEntity, float tickDelta) {
+        LidBlockEntity chest = (LidBlockEntity)blockEntity;
 
-        BlockState state = blockEntity.getCachedState();
-        if (state.contains(ChestBlock.CHEST_TYPE) && state.get(ChestBlock.CHEST_TYPE) != ChestType.SINGLE) {
+        BlockState state = blockEntity.getBlockState();
+        if (state.hasProperty(ChestBlock.TYPE) && state.getValue(ChestBlock.TYPE) != ChestType.SINGLE) {
             BlockEntity neighbor = null;
-            BlockPos pos = blockEntity.getPos();
-            Direction facing = state.get(ChestBlock.FACING);
-            switch (state.get(ChestBlock.CHEST_TYPE)) {
-                case LEFT -> neighbor = blockEntity.getWorld().getBlockEntity(pos.offset(facing.rotateYClockwise()));
-                case RIGHT -> neighbor = blockEntity.getWorld().getBlockEntity(pos.offset(facing.rotateYCounterclockwise()));
+            BlockPos pos = blockEntity.getBlockPos();
+            Direction facing = state.getValue(ChestBlock.FACING);
+            switch (state.getValue(ChestBlock.TYPE)) {
+                case LEFT -> neighbor = blockEntity.getLevel().getBlockEntity(pos.relative(facing.getClockWise()));
+                case RIGHT -> neighbor = blockEntity.getLevel().getBlockEntity(pos.relative(facing.getCounterClockWise()));
             }
-            if (neighbor instanceof LidOpenable) {
-                float nAnim = ((LidOpenable)neighbor).getAnimationProgress(tickDelta);
-                if (nAnim > chest.getAnimationProgress(tickDelta)) {
-                    chest = ((LidOpenable)neighbor);
+            if (neighbor instanceof LidBlockEntity) {
+                float nAnim = ((LidBlockEntity)neighbor).getOpenNess(tickDelta);
+                if (nAnim > chest.getOpenNess(tickDelta)) {
+                    chest = ((LidBlockEntity)neighbor);
                 }
             }
         }

--- a/src/main/java/foundationgames/enhancedblockentities/client/render/entity/DecoratedPotBlockEntityRendererOverride.java
+++ b/src/main/java/foundationgames/enhancedblockentities/client/render/entity/DecoratedPotBlockEntityRendererOverride.java
@@ -4,19 +4,19 @@ import com.google.common.collect.ImmutableMap;
 import foundationgames.enhancedblockentities.client.model.ModelIdentifiers;
 import foundationgames.enhancedblockentities.client.render.BlockEntityRendererOverride;
 import foundationgames.enhancedblockentities.util.EBEUtil;
-import net.minecraft.block.DecoratedPotPattern;
-import net.minecraft.block.DecoratedPotPatterns;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.block.entity.DecoratedPotBlockEntity;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.render.VertexConsumerProvider;
-import net.minecraft.client.render.block.entity.BlockEntityRenderer;
-import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.registry.Registries;
-import net.minecraft.registry.RegistryKey;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.RotationAxis;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.Mth;
+import com.mojang.math.Axis;
+import net.minecraft.world.level.block.DecoratedPotPattern;
+import net.minecraft.world.level.block.DecoratedPotPatterns;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.DecoratedPotBlockEntity;
 
 import java.util.Map;
 
@@ -24,19 +24,19 @@ public class DecoratedPotBlockEntityRendererOverride extends BlockEntityRenderer
     public static final float WOBBLE_STRENGTH = 1f / 64;
 
     private BakedModel baseModel = null;
-    private Map<RegistryKey<DecoratedPotPattern>, BakedModel[]> potPatternModels = null;
+    private Map<ResourceKey<DecoratedPotPattern>, BakedModel[]> potPatternModels = null;
 
     private void tryGetModels() {
-        var models = MinecraftClient.getInstance().getBakedModelManager();
+        var models = Minecraft.getInstance().getModelManager();
 
         if (this.baseModel == null) {
             this.baseModel = models.getModel(ModelIdentifiers.DECORATED_POT_BASE);
         }
 
         if (this.potPatternModels == null) {
-            var builder = ImmutableMap.<RegistryKey<DecoratedPotPattern>, BakedModel[]>builder();
+            var builder = ImmutableMap.<ResourceKey<DecoratedPotPattern>, BakedModel[]>builder();
 
-            Registries.DECORATED_POT_PATTERN.getKeys().forEach(k -> {
+            BuiltInRegistries.DECORATED_POT_PATTERN.registryKeySet().forEach(k -> {
                 var patternModelIDs = ModelIdentifiers.POTTERY_PATTERNS.get(k);
                 BakedModel[] patternPerFaceModels = new BakedModel[patternModelIDs.length];
 
@@ -52,58 +52,58 @@ public class DecoratedPotBlockEntityRendererOverride extends BlockEntityRenderer
     }
 
     @Override
-    public void render(BlockEntityRenderer<BlockEntity> renderer, BlockEntity blockEntity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay) {
+    public void render(BlockEntityRenderer<BlockEntity> renderer, BlockEntity blockEntity, float tickDelta, PoseStack matrices, MultiBufferSource vertexConsumers, int light, int overlay) {
         tryGetModels();
 
         if (blockEntity instanceof DecoratedPotBlockEntity pot) {
-            matrices.push();
+            matrices.pushPose();
 
             var dir = pot.getHorizontalFacing();
 
             matrices.translate(0.5f, 0, 0.5f);
-            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180 - EBEUtil.angle(dir)));
+            matrices.mulPose(Axis.YP.rotationDegrees(180 - EBEUtil.angle(dir)));
             matrices.translate(-0.5f, 0, -0.5f);
 
             var wobbleType = pot.lastWobbleType;
-            if (wobbleType != null && pot.getWorld() != null) {
-                float tilt = ((float)(pot.getWorld().getTime() - pot.lastWobbleTime) + tickDelta) / (float)wobbleType.lengthInTicks;
+            if (wobbleType != null && pot.getLevel() != null) {
+                float tilt = ((float)(pot.getLevel().getGameTime() - pot.lastWobbleTime) + tickDelta) / (float)wobbleType.lengthInTicks;
                 if (tilt >= 0.0F && tilt <= 1.0F) {
                     if (wobbleType == DecoratedPotBlockEntity.WobbleType.POSITIVE) {
-                        float animPeriod = tilt * MathHelper.TAU;
+                        float animPeriod = tilt * Mth.TWO_PI;
 
-                        float tiltX = -1.5f * (MathHelper.cos(animPeriod) + 0.5f) * MathHelper.sin(animPeriod * 0.5f);
-                        matrices.multiply(RotationAxis.POSITIVE_X.rotation(tiltX * WOBBLE_STRENGTH), 0.5f, 0f, 0.5f);
+                        float tiltX = -1.5f * (Mth.cos(animPeriod) + 0.5f) * Mth.sin(animPeriod * 0.5f);
+                        matrices.mulPose(Axis.XP.rotation(tiltX * WOBBLE_STRENGTH));
 
-                        float tiltZ = MathHelper.sin(animPeriod);
-                        matrices.multiply(RotationAxis.POSITIVE_Z.rotation(tiltZ * WOBBLE_STRENGTH), 0.5f, 0f, 0.5f);
+                        float tiltZ = Mth.sin(animPeriod);
+                        matrices.mulPose(Axis.ZP.rotation(tiltZ * WOBBLE_STRENGTH));
                     } else {
-                        float yaw = (1f - tilt) * MathHelper.sin(-tilt * 3 * MathHelper.PI) * 0.125f;
-                        matrices.multiply(RotationAxis.POSITIVE_Y.rotation(yaw), 0.5f, 0f, 0.5f);
+                        float yaw = (1f - tilt) * Mth.sin(-tilt * 3 * Mth.PI) * 0.125f;
+                        matrices.mulPose(Axis.YP.rotation(yaw));
                     }
                 }
             }
 
             var sherds = pot.getSherds();
-            EBEUtil.renderBakedModel(vertexConsumers, blockEntity.getCachedState(), matrices, this.baseModel, light, overlay);
+            EBEUtil.renderBakedModel(vertexConsumers, blockEntity.getBlockState(), matrices, this.baseModel, light, overlay);
 
-            EBEUtil.renderBakedModel(vertexConsumers, blockEntity.getCachedState(), matrices,
+            EBEUtil.renderBakedModel(vertexConsumers, blockEntity.getBlockState(), matrices,
                     this.potPatternModels.get(
                             sherds.back().map(DecoratedPotPatterns::fromSherd).orElse(DecoratedPotPatterns.BLANK)
                     )[0], light, overlay);
-            EBEUtil.renderBakedModel(vertexConsumers, blockEntity.getCachedState(), matrices,
+            EBEUtil.renderBakedModel(vertexConsumers, blockEntity.getBlockState(), matrices,
                     this.potPatternModels.get(
                             sherds.left().map(DecoratedPotPatterns::fromSherd).orElse(DecoratedPotPatterns.BLANK)
                     )[1], light, overlay);
-            EBEUtil.renderBakedModel(vertexConsumers, blockEntity.getCachedState(), matrices,
+            EBEUtil.renderBakedModel(vertexConsumers, blockEntity.getBlockState(), matrices,
                     this.potPatternModels.get(
                             sherds.right().map(DecoratedPotPatterns::fromSherd).orElse(DecoratedPotPatterns.BLANK)
                     )[2], light, overlay);
-            EBEUtil.renderBakedModel(vertexConsumers, blockEntity.getCachedState(), matrices,
+            EBEUtil.renderBakedModel(vertexConsumers, blockEntity.getBlockState(), matrices,
                     this.potPatternModels.get(
                             sherds.front().map(DecoratedPotPatterns::fromSherd).orElse(DecoratedPotPatterns.BLANK)
                     )[3], light, overlay);
 
-            matrices.pop();
+            matrices.popPose();
         }
     }
 

--- a/src/main/java/foundationgames/enhancedblockentities/client/render/entity/ShulkerBoxBlockEntityRendererOverride.java
+++ b/src/main/java/foundationgames/enhancedblockentities/client/render/entity/ShulkerBoxBlockEntityRendererOverride.java
@@ -2,17 +2,17 @@ package foundationgames.enhancedblockentities.client.render.entity;
 
 import foundationgames.enhancedblockentities.client.render.BlockEntityRendererOverride;
 import foundationgames.enhancedblockentities.util.EBEUtil;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.ShulkerBoxBlock;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.block.entity.ShulkerBoxBlockEntity;
-import net.minecraft.client.render.VertexConsumerProvider;
-import net.minecraft.client.render.block.entity.BlockEntityRenderer;
-import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.util.DyeColor;
-import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.RotationAxis;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.Direction;
+import com.mojang.math.Axis;
+import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.level.block.ShulkerBoxBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.ShulkerBoxBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,31 +27,31 @@ public class ShulkerBoxBlockEntityRendererOverride extends BlockEntityRendererOv
     }
 
     @Override
-    public void render(BlockEntityRenderer<BlockEntity> renderer, BlockEntity blockEntity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay) {
+    public void render(BlockEntityRenderer<BlockEntity> renderer, BlockEntity blockEntity, float tickDelta, PoseStack matrices, MultiBufferSource vertexConsumers, int light, int overlay) {
         if (models.isEmpty()) modelMapFiller.accept(models);
         if (blockEntity instanceof ShulkerBoxBlockEntity entity) {
             Direction dir = Direction.UP;
-            BlockState state = entity.getWorld().getBlockState(entity.getPos());
+            BlockState state = entity.getLevel().getBlockState(entity.getBlockPos());
             if (state.getBlock() instanceof ShulkerBoxBlock) {
-                dir = state.get(ShulkerBoxBlock.FACING);
+                dir = state.getValue(ShulkerBoxBlock.FACING);
             }
-            matrices.push();
+            matrices.pushPose();
 
-            float animation = entity.getAnimationProgress(tickDelta);
+            float animation = entity.getProgress(tickDelta);
 
             matrices.translate(0.5, 0.5, 0.5);
-            matrices.multiply(dir.getRotationQuaternion());
-            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(270 * animation));
+            matrices.mulPose(dir.getRotation());
+            matrices.mulPose(Axis.YP.rotationDegrees(270 * animation));
             matrices.translate(-0.5, -0.5, -0.5);
 
             matrices.translate(0, animation * 0.5f, 0);
 
             var lidModel = models.get(entity.getColor());
             if (lidModel != null) {
-                EBEUtil.renderBakedModel(vertexConsumers, blockEntity.getCachedState(), matrices, lidModel, light, overlay);
+                EBEUtil.renderBakedModel(vertexConsumers, blockEntity.getBlockState(), matrices, lidModel, light, overlay);
             }
 
-            matrices.pop();
+            matrices.popPose();
         }
     }
 

--- a/src/main/java/foundationgames/enhancedblockentities/client/render/entity/SignBlockEntityRendererOverride.java
+++ b/src/main/java/foundationgames/enhancedblockentities/client/render/entity/SignBlockEntityRendererOverride.java
@@ -2,25 +2,25 @@ package foundationgames.enhancedblockentities.client.render.entity;
 
 import foundationgames.enhancedblockentities.client.render.BlockEntityRendererOverride;
 import foundationgames.enhancedblockentities.mixin.AbstractSignBlockEntityRenderAccessor;
-import net.minecraft.block.AbstractSignBlock;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.block.entity.SignBlockEntity;
-import net.minecraft.client.render.VertexConsumerProvider;
-import net.minecraft.client.render.block.entity.BlockEntityRenderer;
-import net.minecraft.client.util.math.MatrixStack;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
+import net.minecraft.world.level.block.AbstractSignBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.SignBlockEntity;
 
 public class SignBlockEntityRendererOverride extends BlockEntityRendererOverride {
     public SignBlockEntityRendererOverride() {}
 
     @Override
-    public void render(BlockEntityRenderer<BlockEntity> renderer, BlockEntity blockEntity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay) {
+    public void render(BlockEntityRenderer<BlockEntity> renderer, BlockEntity blockEntity, float tickDelta, PoseStack matrices, MultiBufferSource vertexConsumers, int light, int overlay) {
         if (blockEntity instanceof SignBlockEntity entity) {
-            var state = entity.getCachedState();
+            var state = entity.getBlockState();
             AbstractSignBlock block = (AbstractSignBlock) state.getBlock();
             var sign = (AbstractSignBlockEntityRenderAccessor) renderer;
-            sign.enhanced_bes$applyTransforms(matrices, -block.getRotationDegrees(state), state);
-            sign.enhanced_bes$renderText(entity.getPos(), entity.getFrontText(), matrices, vertexConsumers, light, entity.getTextLineHeight(), entity.getMaxTextWidth(), true);
-            sign.enhanced_bes$renderText(entity.getPos(), entity.getBackText(), matrices, vertexConsumers, light, entity.getTextLineHeight(), entity.getMaxTextWidth(), false);
+            sign.enhanced_bes$applyTransforms(matrices, -block.getYRotationDegrees(state), state);
+            sign.enhanced_bes$renderText(entity.getBlockPos(), entity.getFrontText(), matrices, vertexConsumers, light, entity.getTextLineHeight(), entity.getMaxTextWidth(), true);
+            sign.enhanced_bes$renderText(entity.getBlockPos(), entity.getBackText(), matrices, vertexConsumers, light, entity.getTextLineHeight(), entity.getMaxTextWidth(), false);
         }
     }
 }

--- a/src/main/java/foundationgames/enhancedblockentities/client/resource/AtlasResourceBuilder.java
+++ b/src/main/java/foundationgames/enhancedblockentities/client/resource/AtlasResourceBuilder.java
@@ -3,8 +3,8 @@ package foundationgames.enhancedblockentities.client.resource;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.mojang.serialization.JsonOps;
-import net.minecraft.client.texture.atlas.AtlasSource;
-import net.minecraft.client.texture.atlas.AtlasSourceManager;
+import net.minecraft.client.renderer.texture.atlas.SpriteSource;
+import net.minecraft.client.renderer.texture.atlas.SpriteSourceList;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -12,14 +12,14 @@ import java.util.List;
 
 public class AtlasResourceBuilder {
     private static final Gson GSON = new Gson();
-    private final List<AtlasSource> sources = new ArrayList<>();
+    private final List<SpriteSource> sources = new ArrayList<>();
 
-    public void put(AtlasSource source) {
+    public void put(SpriteSource source) {
         sources.add(source);
     }
 
     public byte[] toBytes() {
-        return GSON.toJson(AtlasSourceManager.LIST_CODEC.encode(this.sources, JsonOps.INSTANCE, new JsonObject())
+        return GSON.toJson(SpriteSourceList.FILE_CODEC.encode(this.sources, JsonOps.INSTANCE, new JsonObject())
                 .getOrThrow())
                 .getBytes(StandardCharsets.UTF_8);
     }

--- a/src/main/java/foundationgames/enhancedblockentities/client/resource/EBEPack.java
+++ b/src/main/java/foundationgames/enhancedblockentities/client/resource/EBEPack.java
@@ -3,19 +3,18 @@ package foundationgames.enhancedblockentities.client.resource;
 import foundationgames.enhancedblockentities.client.resource.template.TemplateLoader;
 import foundationgames.enhancedblockentities.client.resource.template.TemplateProvider;
 import net.minecraft.SharedConstants;
-import net.minecraft.client.texture.atlas.AtlasSource;
-import net.minecraft.client.texture.atlas.DirectoryAtlasSource;
-import net.minecraft.client.texture.atlas.SingleAtlasSource;
-import net.minecraft.resource.InputSupplier;
-import net.minecraft.resource.ResourcePack;
-import net.minecraft.resource.ResourcePackInfo;
-import net.minecraft.resource.ResourcePackSource;
-import net.minecraft.resource.ResourceType;
-import net.minecraft.resource.metadata.PackResourceMetadata;
-import net.minecraft.resource.metadata.ResourceMetadataMap;
-import net.minecraft.resource.metadata.ResourceMetadataSerializer;
-import net.minecraft.text.Text;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.renderer.texture.atlas.SpriteSource;
+import net.minecraft.client.renderer.texture.atlas.sources.DirectoryLister;
+import net.minecraft.client.renderer.texture.atlas.sources.SingleFile;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.PackResources;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.metadata.MetadataSectionSerializer;
+import net.minecraft.server.packs.metadata.pack.PackMetadataSection;
+import net.minecraft.server.packs.repository.Pack;
+import net.minecraft.server.packs.repository.PackSource;
+import net.minecraft.server.packs.resources.IoSupplier;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.ByteArrayInputStream;
@@ -31,83 +30,83 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
-public class EBEPack implements ResourcePack {
-    public static final Identifier BLOCK_ATLAS = Identifier.of("blocks");
+public class EBEPack implements PackResources {
+    public static final ResourceLocation BLOCK_ATLAS = ResourceLocation.parse("blocks");
 
-    private final Map<Identifier, AtlasResourceBuilder> atlases = new HashMap<>();
-    private final Map<Identifier, InputSupplier<InputStream>> resources = new HashMap<>();
+    private final Map<ResourceLocation, AtlasResourceBuilder> atlases = new HashMap<>();
+    private final Map<ResourceLocation, IoSupplier<InputStream>> resources = new HashMap<>();
     private final Set<String> namespaces = new HashSet<>();
 
     private final TemplateLoader templates;
 
-    private final PackResourceMetadata packMeta;
-    private final ResourcePackInfo packInfo;
+    private final PackMetadataSection packMeta;
+    private final Pack.Info packInfo;
 
-    public EBEPack(Identifier id, TemplateLoader templates) {
+    public EBEPack(ResourceLocation id, TemplateLoader templates) {
         this.templates = templates;
 
-        this.packMeta = new PackResourceMetadata(
-                Text.literal("Enhanced Block Entities Resources"),
-                SharedConstants.getGameVersion().getResourceVersion(ResourceType.CLIENT_RESOURCES),
+        this.packMeta = new PackMetadataSection(
+                Component.literal("Enhanced Block Entities Resources"),
+                SharedConstants.getCurrentVersion().getPackVersion(PackType.CLIENT_RESOURCES),
                 Optional.empty());
 
-        this.packInfo = new ResourcePackInfo(id.toString(), Text.literal(id.toString()), ResourcePackSource.BUILTIN, Optional.empty());
+        this.packInfo = new Pack.Info(Component.literal(id.toString()), SharedConstants.getCurrentVersion().getPackVersion(PackType.CLIENT_RESOURCES), PackSource.BUILT_IN, Optional.empty());
     }
 
-    public void addAtlasSprite(Identifier atlas, AtlasSource source) {
+    public void addAtlasSprite(ResourceLocation atlas, SpriteSource source) {
         var resource = this.atlases.computeIfAbsent(atlas, id -> new AtlasResourceBuilder());
         resource.put(source);
 
-        this.addResource(Identifier.of(atlas.getNamespace(), "atlases/" + atlas.getPath() + ".json"), resource::toBytes);
+        this.addResource(ResourceLocation.fromNamespaceAndPath(atlas.getNamespace(), "atlases/" + atlas.getPath() + ".json"), resource::toBytes);
     }
 
-    public void addSingleBlockSprite(Identifier path) {
-        this.addAtlasSprite(BLOCK_ATLAS, new SingleAtlasSource(path, Optional.empty()));
+    public void addSingleBlockSprite(ResourceLocation path) {
+        this.addAtlasSprite(BLOCK_ATLAS, new SingleFile(path, Optional.empty()));
     }
 
     public void addDirBlockSprites(String dir, String prefix) {
-        this.addAtlasSprite(BLOCK_ATLAS, new DirectoryAtlasSource(dir, prefix));
+        this.addAtlasSprite(BLOCK_ATLAS, new DirectoryLister(dir, prefix));
     }
 
-    public void addResource(Identifier id, InputSupplier<byte[]> resource) {
+    public void addResource(ResourceLocation id, IoSupplier<byte[]> resource) {
         this.namespaces.add(id.getNamespace());
         this.resources.put(id, new LazyBufferedResource(resource));
     }
 
-    public void addResource(Identifier id, byte[] resource) {
+    public void addResource(ResourceLocation id, byte[] resource) {
         this.namespaces.add(id.getNamespace());
         this.resources.put(id, () -> new ByteArrayInputStream(resource));
     }
 
-    public void addPlainTextResource(Identifier id, String plainText) {
+    public void addPlainTextResource(ResourceLocation id, String plainText) {
         this.addResource(id, plainText.getBytes(StandardCharsets.UTF_8));
     }
 
-    public void addTemplateResource(Identifier id, TemplateProvider.TemplateApplyingFunction template) {
+    public void addTemplateResource(ResourceLocation id, TemplateProvider.TemplateApplyingFunction template) {
         this.addResource(id, () -> template.getAndApplyTemplate(new TemplateProvider(this.templates)).getBytes(StandardCharsets.UTF_8));
     }
 
-    public void addTemplateResource(Identifier id, String templatePath) {
+    public void addTemplateResource(ResourceLocation id, String templatePath) {
         this.addTemplateResource(id, t -> t.load(templatePath, d -> {}));
     }
 
     @Nullable
     @Override
-    public InputSupplier<InputStream> openRoot(String... segments) {
+    public IoSupplier<InputStream> getRootResource(String... segments) {
         return null; // Provide no root resources
     }
 
     @Nullable
     @Override
-    public InputSupplier<InputStream> open(ResourceType type, Identifier id) {
-        if (type != ResourceType.CLIENT_RESOURCES) return null;
+    public IoSupplier<InputStream> getResource(PackType type, ResourceLocation id) {
+        if (type != PackType.CLIENT_RESOURCES) return null;
 
         return this.resources.get(id);
     }
 
     @Override
-    public void findResources(ResourceType type, String namespace, String prefix, ResultConsumer consumer) {
-        if (type != ResourceType.CLIENT_RESOURCES) return;
+    public void listResources(PackType type, String namespace, String prefix, PackResources.ResourceOutput consumer) {
+        if (type != PackType.CLIENT_RESOURCES) return;
 
         for (var entry : this.resources.entrySet()) {
             var id = entry.getKey();
@@ -119,21 +118,31 @@ public class EBEPack implements ResourcePack {
     }
 
     @Override
-    public Set<String> getNamespaces(ResourceType type) {
-        if (type != ResourceType.CLIENT_RESOURCES) return Set.of();
+    public Set<String> getNamespaces(PackType type) {
+        if (type != PackType.CLIENT_RESOURCES) return Set.of();
 
         return this.namespaces;
     }
 
     @Nullable
     @Override
-    public <T> T parseMetadata(ResourceMetadataSerializer<T> meta) {
-        return ResourceMetadataMap.of(PackResourceMetadata.SERIALIZER, this.packMeta).get(meta);
+    public <T> T getMetadataSection(MetadataSectionSerializer<T> meta) {
+        if (meta == PackMetadataSection.TYPE) {
+            @SuppressWarnings("unchecked")
+            T result = (T) this.packMeta;
+            return result;
+        }
+        return null;
     }
 
     @Override
-    public ResourcePackInfo getInfo() {
+    public Pack.Info packInfo() {
         return this.packInfo;
+    }
+
+    @Override
+    public String packId() {
+        return packInfo.title().getString();
     }
 
     @Override
@@ -181,11 +190,11 @@ public class EBEPack implements ResourcePack {
         }
     }
 
-    public static class LazyBufferedResource implements InputSupplier<InputStream> {
-        private final InputSupplier<byte[]> backing;
+    public static class LazyBufferedResource implements IoSupplier<InputStream> {
+        private final IoSupplier<byte[]> backing;
         private byte[] buffer = null;
 
-        public LazyBufferedResource(InputSupplier<byte[]> backing) {
+        public LazyBufferedResource(IoSupplier<byte[]> backing) {
             this.backing = backing;
         }
 

--- a/src/main/java/foundationgames/enhancedblockentities/config/EBEConfig.java
+++ b/src/main/java/foundationgames/enhancedblockentities/config/EBEConfig.java
@@ -4,7 +4,7 @@ import foundationgames.enhancedblockentities.EnhancedBlockEntities;
 import foundationgames.enhancedblockentities.util.ConvUtil;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
-import net.minecraft.text.Text;
+import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -48,7 +48,7 @@ public class EBEConfig {
     public boolean shulkerBoxAO = false;
     public boolean decoratedPotAO = false;
     public String christmasChests = "allowed";
-    public String signTextRendering = "smart";
+    public String signComponentRendering = "smart";
     public boolean experimentalChests = true;
     public boolean experimentalBeds = true;
     public boolean experimentalSigns = true;
@@ -70,7 +70,7 @@ public class EBEConfig {
         properties.setProperty(SHULKER_BOX_AO_KEY, Boolean.toString(shulkerBoxAO));
         properties.setProperty(DECORATED_POT_AO_KEY, Boolean.toString(decoratedPotAO));
         properties.setProperty(CHRISTMAS_CHESTS_KEY, christmasChests);
-        properties.setProperty(SIGN_TEXT_RENDERING_KEY, signTextRendering);
+        properties.setProperty(SIGN_TEXT_RENDERING_KEY, signComponentRendering);
         properties.setProperty(EXPERIMENTAL_CHESTS_KEY, Boolean.toString(experimentalChests));
         properties.setProperty(EXPERIMENTAL_BEDS_KEY, Boolean.toString(experimentalBeds));
         properties.setProperty(EXPERIMENTAL_SIGNS_KEY, Boolean.toString(experimentalSigns));
@@ -93,10 +93,10 @@ public class EBEConfig {
         }
         String sST = properties.getProperty(SIGN_TEXT_RENDERING_KEY);
         if (sST != null && (sST.equals("smart") || sST.equals("all") || sST.equals("most") || sST.equals("some") || sST.equals("few"))) {
-            this.signTextRendering = sST;
+            this.signComponentRendering = sST;
         } else {
             EnhancedBlockEntities.LOG.warn("Configuration option 'sign_text_rendering' must be one of: 'smart', 'all', 'most', 'some', 'few'");
-            this.signTextRendering = "smart";
+            this.signComponentRendering = "smart";
         }
         this.chestAO = ConvUtil.defaultedBool(properties.getProperty(CHEST_AO_KEY), false);
         this.signAO = ConvUtil.defaultedBool(properties.getProperty(SIGN_AO_KEY), false);
@@ -162,11 +162,11 @@ public class EBEConfig {
         for (var modifier : ebeCompatCfgModifiers) {
             var mod = modifier.getProvider();
             var overrides = new Properties();
-            var reasons = new HashMap<String, Text>();
+            var reasons = new HashMap<String, Component>();
             modifier.getEntrypoint().accept(overrides, reasons);
 
             for (var key : overrides.stringPropertyNames()) {
-                @Nullable Text reason = reasons.get(key);
+                @Nullable Component reason = reasons.get(key);
                 this.overrides.put(key, new Override(mod, reason));
             }
 
@@ -174,5 +174,5 @@ public class EBEConfig {
         }
     }
 
-    public record Override(ModContainer modResponsible, @Nullable Text reason) {}
+    public record Override(ModContainer modResponsible, @Nullable Component reason) {}
 }

--- a/src/main/java/foundationgames/enhancedblockentities/config/gui/option/ConfigButtonOption.java
+++ b/src/main/java/foundationgames/enhancedblockentities/config/gui/option/ConfigButtonOption.java
@@ -2,23 +2,23 @@ package foundationgames.enhancedblockentities.config.gui.option;
 
 import com.mojang.serialization.Codec;
 import foundationgames.enhancedblockentities.config.gui.screen.EBEConfigScreen;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.ClickableWidget;
-import net.minecraft.client.option.GameOptions;
-import net.minecraft.client.option.SimpleOption;
-import net.minecraft.text.Text;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.OptionInstance;
+import net.minecraft.client.Options;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
 
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class ConfigButtonOption {
-    public static SimpleOption<?> getOption(Screen parent) {
-        return new SimpleOption<>(
+    public static OptionInstance<?> getOption(Screen parent) {
+        return new OptionInstance<>(
             "option.ebe.config",
-            SimpleOption.emptyTooltip(),
+            OptionInstance.noTooltip(),
             (title, object) -> title,
             new ConfigButtonCallbacks<>(parent),
             Optional.empty(),
@@ -27,16 +27,16 @@ public class ConfigButtonOption {
         );
     }
 
-    private record ConfigButtonCallbacks<T>(Screen parent) implements SimpleOption.Callbacks<T> {
+    private record ConfigButtonCallbacks<T>(Screen parent) implements OptionInstance.Enum<T> {
         @Override
-        public Function<SimpleOption<T>, ClickableWidget> getWidgetCreator(SimpleOption.TooltipFactory<T> tooltipFactory, GameOptions gameOptions, int x, int y, int width, Consumer<T> changed) {
-            return (option) -> ButtonWidget.builder(Text.translatable("option.ebe.config"), b -> {
-                MinecraftClient.getInstance().setScreen(new EBEConfigScreen(parent));
-            }).dimensions(x, y, width, 20).build();
+        public Function<OptionInstance<T>, AbstractWidget> createButton(OptionInstance.TooltipSupplier<T> tooltipFactory, Options gameOptions, int x, int y, int width, Consumer<T> changed) {
+            return (option) -> Button.builder(Component.translatable("option.ebe.config"), b -> {
+                Minecraft.getInstance().setScreen(new EBEConfigScreen(parent));
+            }).bounds(x, y, width, 20).build();
         }
 
         @Override
-        public Optional<T> validate(T value) {
+        public Optional<T> validateValue(T value) {
             return Optional.empty();
         }
 

--- a/src/main/java/foundationgames/enhancedblockentities/config/gui/option/EBEOption.java
+++ b/src/main/java/foundationgames/enhancedblockentities/config/gui/option/EBEOption.java
@@ -3,11 +3,11 @@ package foundationgames.enhancedblockentities.config.gui.option;
 import foundationgames.enhancedblockentities.ReloadType;
 import foundationgames.enhancedblockentities.config.EBEConfig;
 import foundationgames.enhancedblockentities.util.GuiUtil;
-import net.minecraft.client.gui.tooltip.Tooltip;
-import net.minecraft.client.resource.language.I18n;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
-import net.minecraft.util.math.MathHelper;
+import net.minecraft.ChatChatFormatting;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.resources.language.I18n;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -15,16 +15,16 @@ import java.util.Map;
 import java.util.Properties;
 
 public final class EBEOption {
-    private static final Text NEWLINE = Text.of("\n");
+    private static final Component NEWLINE = Component.of("\n");
     private static final String OPTION_VALUE = "options.generic_value";
     private static final String DIVIDER = "text.ebe.option_value_division";
     private static final String OVERRIDDEN = "warning.ebe.overridden";
 
     public final String key;
     public final boolean hasValueComments;
-    public final Text comment;
+    public final Component comment;
     public final ReloadType reloadType;
-    public final TextPalette palette;
+    public final ComponentPalette palette;
     public final @Nullable EBEConfig.Override override;
 
     private final List<String> values;
@@ -32,12 +32,12 @@ public final class EBEOption {
 
     private int selected;
     private Tooltip tooltip = null;
-    private Text text = null;
+    private Component text = null;
 
-    public EBEOption(String key, List<String> values, ConfigView config, boolean hasValueComments, TextPalette palette, ReloadType reloadType) {
+    public EBEOption(String key, List<String> values, ConfigView config, boolean hasValueComments, ComponentPalette palette, ReloadType reloadType) {
         this.key = key;
         this.values = values;
-        this.defaultValue = MathHelper.clamp(values.indexOf(config.configValues.getProperty(key)), 0, values.size());
+        this.defaultValue = Mth.clamp(values.indexOf(config.configValues.getProperty(key)), 0, values.size());
         this.override = config.overrides.get(key);
         this.selected = this.defaultValue;
         this.hasValueComments = hasValueComments;
@@ -60,26 +60,26 @@ public final class EBEOption {
         return String.format("value.ebe.%s", getValue());
     }
 
-    public Text getText() {
-        var option = Text.translatable(this.getOptionKey()).styled(style -> style.withColor(isDefault() ? 0xFFFFFF : 0xFFDA5E));
-        var value = Text.translatable(this.getValueKey()).styled(style -> style.withColor(this.palette.getColor((float)this.selected / this.values.size())));
+    public Component getComponent() {
+        var option = Component.translatable(this.getOptionKey()).styled(style -> style.withColor(isDefault() ? 0xFFFFFF : 0xFFDA5E));
+        var value = Component.translatable(this.getValueKey()).styled(style -> style.withColor(this.palette.getColor((float)this.selected / this.values.size())));
 
-        if (text == null) text = option.append(Text.translatable(DIVIDER).append(value));
+        if (text == null) text = option.append(Component.translatable(DIVIDER).append(value));
         return text;
     }
 
     public Tooltip getTooltip() {
         if (tooltip == null) {
             if (override != null) {
-                var text = Text.translatable(OVERRIDDEN, override.modResponsible().getMetadata().getId())
-                        .formatted(Formatting.RED, Formatting.UNDERLINE);
+                var text = Component.translatable(OVERRIDDEN, override.modResponsible().getMetadata().getId())
+                        .formatted(ChatFormatting.RED, ChatFormatting.UNDERLINE);
                 if (override.reason() != null) {
                     text.append(NEWLINE).append(override.reason());
                 }
 
                 tooltip = Tooltip.of(text);
             }
-            else if (hasValueComments) tooltip = Tooltip.of(Text.translatable(String.format("option.ebe.%s.valueComment.%s", key, getValue())).append(NEWLINE).append(comment.copyContentOnly()));
+            else if (hasValueComments) tooltip = Tooltip.of(Component.translatable(String.format("option.ebe.%s.valueComment.%s", key, getValue())).append(NEWLINE).append(comment.copyContentOnly()));
             else tooltip = Tooltip.of(comment.copyContentOnly());
         }
         return tooltip;

--- a/src/main/java/foundationgames/enhancedblockentities/config/gui/screen/EBEConfigScreen.java
+++ b/src/main/java/foundationgames/enhancedblockentities/config/gui/screen/EBEConfigScreen.java
@@ -10,15 +10,15 @@ import foundationgames.enhancedblockentities.config.gui.widget.SectionTextWidget
 import foundationgames.enhancedblockentities.config.gui.widget.WidgetRowListWidget;
 import foundationgames.enhancedblockentities.util.EBEUtil;
 import foundationgames.enhancedblockentities.util.GuiUtil;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.tooltip.Tooltip;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.GridWidget;
-import net.minecraft.client.resource.language.I18n;
-import net.minecraft.screen.ScreenTexts;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
+import net.minecraft.ChatChatFormatting;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.GridLayout;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.resources.language.I18n;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -35,21 +35,21 @@ public class EBEConfigScreen extends Screen {
     private static final ImmutableList<String> ALLOWED_FORCED_DISABLED = ImmutableList.of("allowed", "forced", "disabled");
     private static final ImmutableList<String> SIGN_TEXT_OPTIONS = ImmutableList.of("smart", "all", "most", "some", "few");
 
-    private static final Text HOLD_SHIFT = Text.translatable("text.ebe.descriptions").formatted(Formatting.GRAY, Formatting.ITALIC);
-    private static final Text CHEST_OPTIONS_TITLE = Text.translatable("text.ebe.chest_options");
-    private static final Text SIGN_OPTIONS_TITLE = Text.translatable("text.ebe.sign_options");
-    private static final Text BELL_OPTIONS_TITLE = Text.translatable("text.ebe.bell_options");
-    private static final Text BED_OPTIONS_TITLE = Text.translatable("text.ebe.bed_options");
-    private static final Text SHULKER_BOX_OPTIONS_TITLE = Text.translatable("text.ebe.shulker_box_options");
-    private static final Text DECORATED_POT_OPTIONS_TITLE = Text.translatable("text.ebe.decorated_pot_options");
-    private static final Text ADVANCED_TITLE = Text.translatable("text.ebe.advanced");
+    private static final Component HOLD_SHIFT = Component.translatable("text.ebe.descriptions").formatted(ChatFormatting.GRAY, ChatFormatting.ITALIC);
+    private static final Component CHEST_OPTIONS_TITLE = Component.translatable("text.ebe.chest_options");
+    private static final Component SIGN_OPTIONS_TITLE = Component.translatable("text.ebe.sign_options");
+    private static final Component BELL_OPTIONS_TITLE = Component.translatable("text.ebe.bell_options");
+    private static final Component BED_OPTIONS_TITLE = Component.translatable("text.ebe.bed_options");
+    private static final Component SHULKER_BOX_OPTIONS_TITLE = Component.translatable("text.ebe.shulker_box_options");
+    private static final Component DECORATED_POT_OPTIONS_TITLE = Component.translatable("text.ebe.decorated_pot_options");
+    private static final Component ADVANCED_TITLE = Component.translatable("text.ebe.advanced");
 
-    private static final Text DUMP_LABEL = Text.translatable("option.ebe.dump");
+    private static final Component DUMP_LABEL = Component.translatable("option.ebe.dump");
 
-    private final Text dumpTooltip = GuiUtil.shorten(I18n.translate("option.ebe.dump.comment"), 20);
+    private final Component dumpTooltip = GuiUtil.shorten(I18n.translate("option.ebe.dump.comment"), 20);
 
     public EBEConfigScreen(Screen screen) {
-        super(Text.translatable("screen.ebe.config"));
+        super(Component.translatable("screen.ebe.config"));
         parent = screen;
     }
 
@@ -57,22 +57,22 @@ public class EBEConfigScreen extends Screen {
     protected void init() {
         super.init();
 
-        this.optionsWidget = new WidgetRowListWidget(this.client, this.width, this.height - 69, 34, 316, 20);
+        this.optionsWidget = new WidgetRowListWidget(this.minecraft, this.width, this.height - 69, 34, 316, 20);
         this.options.clear();
 
         addOptions();
-        this.addDrawableChild(optionsWidget);
+        this.addRenderableWidget(optionsWidget);
 
-        var menuButtons = new GridWidget();
+        var menuButtons = new GridLayout();
         menuButtons.setColumnSpacing(4);
 
         var menuButtonAdder = menuButtons.createAdder(3);
 
-        menuButtonAdder.add(ButtonWidget.builder(ScreenTexts.CANCEL, button -> this.close())
+        menuButtonAdder.add(Button.builder(CommonComponents.GUI_CANCEL, button -> this.close())
                 .size(100, 20).build());
-        menuButtonAdder.add(ButtonWidget.builder(Text.translatable("text.ebe.apply"), button -> this.applyChanges())
+        menuButtonAdder.add(Button.builder(Component.translatable("text.ebe.apply"), button -> this.applyChanges())
                 .size(100, 20).build());
-        menuButtonAdder.add(ButtonWidget.builder(ScreenTexts.DONE,
+        menuButtonAdder.add(Button.builder(CommonComponents.GUI_DONE,
                 button -> {
                     applyChanges();
                     close();
@@ -83,27 +83,28 @@ public class EBEConfigScreen extends Screen {
         menuButtons.setPosition((this.width - menuButtons.getWidth()) / 2, this.height - 27);
         menuButtons.forEachChild((child) -> {
             child.setNavigationOrder(1);
-            this.addDrawableChild(child);
+            this.addRenderableWidget(child);
         });
     }
 
     @Override
-    protected void renderDarkening(DrawContext context) {
+    protected void renderDarkening(GuiGraphics context) {
         renderDarkening(context, 0, 0, this.width, 34);
         renderDarkening(context, 0, this.height - 35, this.width, 35);
     }
 
     @Override
-    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+    public void render(GuiGraphics context, int mouseX, int mouseY, float delta) {
         super.render(context, mouseX, mouseY, delta);
 
-        context.drawCenteredTextWithShadow(this.textRenderer, this.title, (int)(this.width * 0.5), 8, 0xFFFFFF);
-        context.drawCenteredTextWithShadow(this.textRenderer, HOLD_SHIFT, (int)(this.width * 0.5), 21, 0xFFFFFF);
+        context.drawCenteredString(this.font, this.title, (int)(this.width * 0.5), 8, 0xFFFFFF);
+        context.drawCenteredString(this.font, HOLD_SHIFT, (int)(this.width * 0.5), 21, 0xFFFFFF);
     }
 
     @Override
     public void close() {
-        this.client.setScreen(parent);
+        this.minecraft.setScreen(parent);
+
     }
 
     public void applyChanges() {
@@ -126,7 +127,7 @@ public class EBEConfigScreen extends Screen {
         EnhancedBlockEntities.CONFIG.writeTo(config);
 
         final var configView = new EBEOption.ConfigView(config, EnhancedBlockEntities.CONFIG.overrides);
-        final var textRenderer = this.client.textRenderer;
+        final var textRenderer = this.minecraft.font;
 
         optionsWidget.add(new SectionTextWidget(CHEST_OPTIONS_TITLE, textRenderer));
         optionsWidget.add(option(
@@ -192,7 +193,7 @@ public class EBEConfigScreen extends Screen {
         optionsWidget.add(option(
                 new EBEOption(EBEConfig.FORCE_RESOURCE_PACK_COMPAT_KEY, BOOLEAN_OPTIONS, configView, false, TextPalette.ON_OFF, ReloadType.RESOURCES)
         ));
-        optionsWidget.add(ButtonWidget.builder(DUMP_LABEL, b -> {
+        optionsWidget.add(Button.builder(DUMP_LABEL, b -> {
             try {
                 EBEUtil.dumpResources();
             } catch (IOException e) {
@@ -201,10 +202,10 @@ public class EBEConfigScreen extends Screen {
         }).tooltip(Tooltip.of(dumpTooltip)).build());
     }
 
-    private ButtonWidget option(EBEOption option) {
+    private Button option(EBEOption option) {
         options.add(option);
 
-        var button = ButtonWidget.builder(option.getText(), b -> {
+        var button = Button.builder(option.getText(), b -> {
             option.next();
             b.setMessage(option.getText());
             b.setTooltip(option.getTooltip());

--- a/src/main/java/foundationgames/enhancedblockentities/config/gui/widget/SectionTextWidget.java
+++ b/src/main/java/foundationgames/enhancedblockentities/config/gui/widget/SectionTextWidget.java
@@ -1,24 +1,24 @@
 package foundationgames.enhancedblockentities.config.gui.widget;
 
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.widget.AbstractTextWidget;
-import net.minecraft.text.Text;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractTextWidget;
+import net.minecraft.network.chat.Component;
 
 public class SectionTextWidget extends AbstractTextWidget {
-    public SectionTextWidget(Text message, TextRenderer textRenderer) {
+    public SectionTextWidget(Component message, Font textRenderer) {
         this(0, 0, 200, 20, message, textRenderer);
     }
 
-    public SectionTextWidget(int x, int y, int width, int height, Text message, TextRenderer textRenderer) {
+    public SectionTextWidget(int x, int y, int width, int height, Component message, Font textRenderer) {
         super(x, y, width, height, message, textRenderer);
         this.active = false;
     }
 
     @Override
-    public void renderWidget(DrawContext context, int mouseX, int mouseY, float delta) {
+    public void renderWidget(GuiGraphics context, int mouseX, int mouseY, float delta) {
         final int white = 0xFFFFFFFF;
-        var font = this.getTextRenderer();
+        var font = this.getFont();
         var msg = this.getMessage();
 
         int l = this.getX();
@@ -27,8 +27,8 @@ public class SectionTextWidget extends AbstractTextWidget {
         int y = (this.getY() + this.getHeight()) - 6;
 
         int tx = l + (w / 2);
-        int ty = y - (font.fontHeight / 2);
-        int tw = font.getWidth(msg);
+        int ty = y - (font.lineHeight / 2);
+        int tw = font.width(msg);
 
         int ml = l + ((w - tw) / 2) - 5;
         int mr = ml + tw + 10;
@@ -39,6 +39,6 @@ public class SectionTextWidget extends AbstractTextWidget {
         context.fill(l, y, ml, y + 2, white);
         context.fill(mr, y, r, y + 2, white);
 
-        context.drawCenteredTextWithShadow(font, msg, tx, ty, 0xFFFFFF);
+        context.drawCenteredString(font, msg, tx, ty, 0xFFFFFF);
     }
 }

--- a/src/main/java/foundationgames/enhancedblockentities/config/gui/widget/WidgetRowListWidget.java
+++ b/src/main/java/foundationgames/enhancedblockentities/config/gui/widget/WidgetRowListWidget.java
@@ -1,43 +1,43 @@
 package foundationgames.enhancedblockentities.config.gui.widget;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.Element;
-import net.minecraft.client.gui.Selectable;
-import net.minecraft.client.gui.widget.ClickableWidget;
-import net.minecraft.client.gui.widget.ElementListWidget;
-import net.minecraft.client.gui.widget.GridWidget;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.ContainerObjectSelectionList;
+import net.minecraft.client.gui.components.GridLayout;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarratableEntry;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class WidgetRowListWidget extends ElementListWidget<WidgetRowListWidget.Entry> {
+public class WidgetRowListWidget extends ContainerObjectSelectionList<WidgetRowListWidget.Entry> {
     public static final int SPACING = 3;
 
     public final int rowWidth;
     public final int rowHeight;
 
-    public WidgetRowListWidget(MinecraftClient mc, int w, int h, int y, int rowWidth, int rowHeight) {
+    public WidgetRowListWidget(Minecraft mc, int w, int h, int y, int rowWidth, int rowHeight) {
         super(mc, w, h, y, rowHeight + SPACING);
         this.rowWidth = rowWidth;
         this.rowHeight = rowHeight;
     }
 
-    public void add(ClickableWidget ... widgets) {
+    public void add(AbstractWidget ... widgets) {
         if (widgets.length == 0) return;
 
-        var grid = new GridWidget();
+        var grid = new GridLayout();
         grid.setColumnSpacing(SPACING);
         var adder = grid.createAdder(widgets.length);
 
         int width = (this.rowWidth - ((widgets.length - 1) * SPACING)) / widgets.length;
 
         for (var widget : widgets) {
-            widget.setDimensions(width, this.rowHeight);
+            widget.setSize(width, this.rowHeight);
             adder.add(widget);
         }
 
-        grid.refreshPositions();
+        grid.arrangeElements();
 
         this.addEntry(new Entry(grid));
     }
@@ -48,39 +48,39 @@ public class WidgetRowListWidget extends ElementListWidget<WidgetRowListWidget.E
     }
 
     @Override
-    protected int getScrollbarX() {
+    protected int scrollBarX() {
         return this.width - 6;
     }
 
     @Override
-    protected void drawMenuListBackground(DrawContext context) {
+    protected void renderListBackground(GuiGraphics context) {
     }
 
-    public static class Entry extends ElementListWidget.Entry<Entry> {
-        private final GridWidget widget;
-        private final List<ClickableWidget> children = new ArrayList<>();
+    public static class Entry extends ContainerObjectSelectionList.Entry<Entry> {
+        private final GridLayout widget;
+        private final List<AbstractWidget> children = new ArrayList<>();
 
-        public Entry(GridWidget widget) {
+        public Entry(GridLayout widget) {
             this.widget = widget;
-            widget.forEachChild(children::add);
+            widget.visitWidgets(children::add);
         }
 
         @Override
-        public List<? extends Element> children() {
+        public List<? extends GuiEventListener> children() {
             return this.children;
         }
 
         @Override
-        public List<? extends Selectable> selectableChildren() {
+        public List<? extends NarratableEntry> narratables() {
             return this.children;
         }
 
         @Override
-        public void render(DrawContext context, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
+        public void render(GuiGraphics context, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float tickDelta) {
             this.widget.setPosition(x - 3, y);
-            this.widget.refreshPositions();
+            this.widget.arrangeElements();
 
-            this.widget.forEachChild(c -> c.render(context, mouseX, mouseY, tickDelta));
+            this.widget.visitWidgets(c -> c.render(context, mouseX, mouseY, tickDelta));
         }
     }
 }

--- a/src/main/java/foundationgames/enhancedblockentities/mixin/AbstractBlockStateMixin.java
+++ b/src/main/java/foundationgames/enhancedblockentities/mixin/AbstractBlockStateMixin.java
@@ -1,24 +1,24 @@
 package foundationgames.enhancedblockentities.mixin;
 
 import foundationgames.enhancedblockentities.EnhancedBlockEntityRegistry;
-import net.minecraft.block.AbstractBlock;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockRenderType;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.RenderShape;
+import net.minecraft.world.level.block.state.BlockBehaviour;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(AbstractBlock.AbstractBlockState.class)
+@Mixin(BlockBehaviour.BlockStateBase.class)
 public abstract class AbstractBlockStateMixin {
     @Shadow public abstract Block getBlock();
 
-    @Inject(method = "getRenderType", at = @At("HEAD"), cancellable = true)
-    public void enhanced_bes$overrideRenderType(CallbackInfoReturnable<BlockRenderType> cir) {
+    @Inject(method = "getRenderShape", at = @At("HEAD"), cancellable = true)
+    public void enhanced_bes$overrideRenderType(CallbackInfoReturnable<RenderShape> cir) {
         Block block = this.getBlock();
         if (EnhancedBlockEntityRegistry.BLOCKS.contains(block)) {
-            cir.setReturnValue(BlockRenderType.MODEL);
+            cir.setReturnValue(RenderShape.MODEL);
         }
     }
 }

--- a/src/main/java/foundationgames/enhancedblockentities/mixin/AbstractSignBlockEntityRenderAccessor.java
+++ b/src/main/java/foundationgames/enhancedblockentities/mixin/AbstractSignBlockEntityRenderAccessor.java
@@ -1,22 +1,22 @@
 package foundationgames.enhancedblockentities.mixin;
 
-import net.minecraft.block.BlockState;
-import net.minecraft.block.entity.SignText;
-import net.minecraft.client.render.VertexConsumerProvider;
-import net.minecraft.client.render.block.entity.AbstractSignBlockEntityRenderer;
-import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.util.math.BlockPos;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.blockentity.SignRenderer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.SignText;
+import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
-@Mixin(AbstractSignBlockEntityRenderer.class)
+@Mixin(SignRenderer.class)
 public interface AbstractSignBlockEntityRenderAccessor {
-    @Invoker("applyTransforms")
-    void enhanced_bes$applyTransforms(MatrixStack matrices, float rotationDegrees, BlockState state);
+    @Invoker("translateSign")
+    void enhanced_bes$applyTransforms(PoseStack matrices, float rotationDegrees, BlockState state);
 
-    @Invoker("renderText")
-    void enhanced_bes$renderText(BlockPos pos, SignText signText, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int lineHeight, int lineWidth, boolean front);
+    @Invoker("renderSignText")
+    void enhanced_bes$renderText(BlockPos pos, SignText signText, PoseStack matrices, MultiBufferSource vertexConsumers, int light, int lineHeight, int lineWidth, boolean front);
 
     @Accessor("MAX_COLORED_TEXT_OUTLINE_RENDER_DISTANCE")
     static int enhanced_bes$getRenderDistance() {

--- a/src/main/java/foundationgames/enhancedblockentities/mixin/BellBlockEntityMixin.java
+++ b/src/main/java/foundationgames/enhancedblockentities/mixin/BellBlockEntityMixin.java
@@ -2,11 +2,11 @@ package foundationgames.enhancedblockentities.mixin;
 
 import foundationgames.enhancedblockentities.EnhancedBlockEntities;
 import foundationgames.enhancedblockentities.util.duck.AppearanceStateHolder;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.entity.BellBlockEntity;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.block.entity.BlockEntityType;
-import net.minecraft.util.math.BlockPos;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BellBlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -30,7 +30,7 @@ public class BellBlockEntityMixin extends BlockEntity implements AppearanceState
     private static BellBlockEntity enhanced_bes$listenForStopRinging(BellBlockEntity blockEntity) {
         int mState = blockEntity.ringTicks > 0 ? 1 : 0;
         if (EnhancedBlockEntities.CONFIG.renderEnhancedBells && ((AppearanceStateHolder)blockEntity).getModelState() != mState) {
-            ((AppearanceStateHolder)blockEntity).updateAppearanceState(mState, blockEntity.getWorld(), blockEntity.getPos());
+            ((AppearanceStateHolder)blockEntity).updateAppearanceState(mState, blockEntity.getLevel(), blockEntity.getBlockPos());
         }
         return blockEntity;
     }

--- a/src/main/java/foundationgames/enhancedblockentities/mixin/BlockEntityRenderDispatcherMixin.java
+++ b/src/main/java/foundationgames/enhancedblockentities/mixin/BlockEntityRenderDispatcherMixin.java
@@ -1,16 +1,16 @@
 package foundationgames.enhancedblockentities.mixin;
 
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.datafixers.util.Pair;
 import foundationgames.enhancedblockentities.EnhancedBlockEntityRegistry;
 import foundationgames.enhancedblockentities.client.render.BlockEntityRenderCondition;
 import foundationgames.enhancedblockentities.client.render.BlockEntityRendererOverride;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.client.render.OverlayTexture;
-import net.minecraft.client.render.VertexConsumerProvider;
-import net.minecraft.client.render.WorldRenderer;
-import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
-import net.minecraft.client.render.block.entity.BlockEntityRenderer;
-import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.util.Pair;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -19,15 +19,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(BlockEntityRenderDispatcher.class)
 public class BlockEntityRenderDispatcherMixin {
     @Inject(
-            method = "render(Lnet/minecraft/client/render/block/entity/BlockEntityRenderer;Lnet/minecraft/block/entity/BlockEntity;FLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;)V",
+            method = "render(Lnet/minecraft/client/renderer/blockentity/BlockEntityRenderer;Lnet/minecraft/world/level/block/entity/BlockEntity;FLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;)V",
             at = @At("HEAD"),
             cancellable = true
     )
-    private static void enhanced_bes$renderOverrides(BlockEntityRenderer<BlockEntity> renderer, BlockEntity blockEntity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, CallbackInfo ci) {
-        if (EnhancedBlockEntityRegistry.ENTITIES.containsKey(blockEntity.getType()) && EnhancedBlockEntityRegistry.BLOCKS.contains(blockEntity.getCachedState().getBlock())) {
+    private static void enhanced_bes$renderOverrides(BlockEntityRenderer<BlockEntity> renderer, BlockEntity blockEntity, float tickDelta, PoseStack matrices, MultiBufferSource vertexConsumers, CallbackInfo ci) {
+        if (EnhancedBlockEntityRegistry.ENTITIES.containsKey(blockEntity.getType()) && EnhancedBlockEntityRegistry.BLOCKS.contains(blockEntity.getBlockState().getBlock())) {
             Pair<BlockEntityRenderCondition, BlockEntityRendererOverride> entry = EnhancedBlockEntityRegistry.ENTITIES.get(blockEntity.getType());
-            if (entry.getLeft().shouldRender(blockEntity)) {
-                entry.getRight().render(renderer, blockEntity, tickDelta, matrices, vertexConsumers, WorldRenderer.getLightmapCoordinates(blockEntity.getWorld(), blockEntity.getPos()), OverlayTexture.DEFAULT_UV);
+            if (entry.getFirst().shouldRender(blockEntity)) {
+                entry.getSecond().render(renderer, blockEntity, tickDelta, matrices, vertexConsumers, LevelRenderer.getLightColor(blockEntity.getLevel(), blockEntity.getBlockPos()), OverlayTexture.NO_OVERLAY);
             }
             ci.cancel();
         }

--- a/src/main/java/foundationgames/enhancedblockentities/mixin/BuiltChunkMixin.java
+++ b/src/main/java/foundationgames/enhancedblockentities/mixin/BuiltChunkMixin.java
@@ -1,12 +1,12 @@
 package foundationgames.enhancedblockentities.mixin;
 
 import foundationgames.enhancedblockentities.util.duck.ChunkRebuildTaskAccess;
-import net.minecraft.client.render.chunk.ChunkBuilder;
+import net.minecraft.client.renderer.chunk.ChunkRenderDispatcher;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
-@Mixin(ChunkBuilder.BuiltChunk.class)
+@Mixin(ChunkRenderDispatcher.RenderChunk.class)
 public class BuiltChunkMixin implements ChunkRebuildTaskAccess {
     private @Unique
     @Nullable Runnable enhanced_bes$taskAfterRebuild = null;

--- a/src/main/java/foundationgames/enhancedblockentities/mixin/ChestBlockEntityMixin.java
+++ b/src/main/java/foundationgames/enhancedblockentities/mixin/ChestBlockEntityMixin.java
@@ -3,12 +3,12 @@ package foundationgames.enhancedblockentities.mixin;
 import foundationgames.enhancedblockentities.EnhancedBlockEntities;
 import foundationgames.enhancedblockentities.client.render.entity.ChestBlockEntityRendererOverride;
 import foundationgames.enhancedblockentities.util.duck.AppearanceStateHolder;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.block.entity.BlockEntityType;
-import net.minecraft.block.entity.ChestBlockEntity;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -25,9 +25,9 @@ public abstract class ChestBlockEntityMixin extends BlockEntity implements Appea
     }
 
     @Inject(method = "clientTick", at = @At(value = "TAIL"))
-    private static void enhanced_bes$listenForOpenClose(World world, BlockPos pos, BlockState state, ChestBlockEntity blockEntity, CallbackInfo ci) {
+    private static void enhanced_bes$listenForOpenClose(Level world, BlockPos pos, BlockState state, ChestBlockEntity blockEntity, CallbackInfo ci) {
         var lid = ChestBlockEntityRendererOverride.getLidAnimationHolder(blockEntity, 0.5f);
-        int mState = lid.getAnimationProgress(0.5f) > 0 ? 1 : 0;
+        int mState = lid.getOpenNess(0.5f) > 0 ? 1 : 0;
 
         if (EnhancedBlockEntities.CONFIG.renderEnhancedChests && ((AppearanceStateHolder)blockEntity).getModelState() != mState) {
             ((AppearanceStateHolder)blockEntity).updateAppearanceState(mState, world, pos);

--- a/src/main/java/foundationgames/enhancedblockentities/mixin/DecoratedPotBlockEntityMixin.java
+++ b/src/main/java/foundationgames/enhancedblockentities/mixin/DecoratedPotBlockEntityMixin.java
@@ -2,9 +2,9 @@ package foundationgames.enhancedblockentities.mixin;
 
 import foundationgames.enhancedblockentities.util.WorldUtil;
 import foundationgames.enhancedblockentities.util.duck.AppearanceStateHolder;
-import net.minecraft.block.entity.DecoratedPotBlockEntity;
-import net.minecraft.nbt.NbtCompound;
-import net.minecraft.registry.RegistryWrapper;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.block.entity.DecoratedPotBlockEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -17,30 +17,30 @@ public class DecoratedPotBlockEntityMixin implements AppearanceStateHolder {
     @Unique private int enhanced_bes$modelState = 0;
     @Unique private int enhanced_bes$renderState = 0;
 
-    @Inject(method = "readNbt", at = @At("TAIL"))
-    private void enhanced_bes$updateChunkOnPatternsLoaded(NbtCompound nbt, RegistryWrapper.WrapperLookup rwl, CallbackInfo ci) {
+    @Inject(method = "loadAdditional", at = @At("TAIL"))
+    private void enhanced_bes$updateChunkOnPatternsLoaded(CompoundTag nbt, HolderLookup.Provider rwl, CallbackInfo ci) {
         var self = (DecoratedPotBlockEntity)(Object)this;
 
-        if (self.getWorld() != null && self.getWorld().isClient()) {
-            WorldUtil.rebuildChunk(self.getWorld(), self.getPos());
+        if (self.getLevel() != null && self.getLevel().isClientSide()) {
+            WorldUtil.rebuildChunk(self.getLevel(), self.getBlockPos());
         }
     }
 
-    @Inject(method = "onSyncedBlockEvent", at = @At(value = "RETURN", shift = At.Shift.BEFORE, ordinal = 0))
+    @Inject(method = "triggerEvent", at = @At(value = "RETURN", shift = At.Shift.BEFORE, ordinal = 0))
     private void enhanced_bes$updateOnWobble(int type, int data, CallbackInfoReturnable<Boolean> cir) {
         var self = (DecoratedPotBlockEntity)(Object)this;
-        var world = self.getWorld();
+        var world = self.getLevel();
 
         if (self.lastWobbleType == null) {
             return;
         }
 
-        this.updateAppearanceState(1, world, self.getPos());
+        this.updateAppearanceState(1, world, self.getBlockPos());
 
         WorldUtil.scheduleTimed(world, self.lastWobbleTime + self.lastWobbleType.lengthInTicks,
                 () -> {
-                    if (self.getWorld().getTime() >= self.lastWobbleTime + self.lastWobbleType.lengthInTicks) {
-                        this.updateAppearanceState(0, world, self.getPos());
+                    if (self.getLevel().getGameTime() >= self.lastWobbleTime + self.lastWobbleType.lengthInTicks) {
+                        this.updateAppearanceState(0, world, self.getBlockPos());
                     }
                 });
     }

--- a/src/main/java/foundationgames/enhancedblockentities/mixin/EnderChestBlockEntityMixin.java
+++ b/src/main/java/foundationgames/enhancedblockentities/mixin/EnderChestBlockEntityMixin.java
@@ -3,12 +3,12 @@ package foundationgames.enhancedblockentities.mixin;
 import foundationgames.enhancedblockentities.EnhancedBlockEntities;
 import foundationgames.enhancedblockentities.client.render.entity.ChestBlockEntityRendererOverride;
 import foundationgames.enhancedblockentities.util.duck.AppearanceStateHolder;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.block.entity.BlockEntityType;
-import net.minecraft.block.entity.EnderChestBlockEntity;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.entity.EnderChestBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -25,9 +25,9 @@ public abstract class EnderChestBlockEntityMixin extends BlockEntity implements 
     }
 
     @Inject(method = "clientTick", at = @At(value = "TAIL"))
-    private static void enhanced_bes$listenForOpenClose(World world, BlockPos pos, BlockState state, EnderChestBlockEntity blockEntity, CallbackInfo ci) {
+    private static void enhanced_bes$listenForOpenClose(Level world, BlockPos pos, BlockState state, EnderChestBlockEntity blockEntity, CallbackInfo ci) {
         var lid = ChestBlockEntityRendererOverride.getLidAnimationHolder(blockEntity, 0.5f);
-        int mState = lid.getAnimationProgress(0.5f) > 0 ? 1 : 0;
+        int mState = lid.getOpenNess(0.5f) > 0 ? 1 : 0;
 
         if (EnhancedBlockEntities.CONFIG.renderEnhancedChests && ((AppearanceStateHolder)blockEntity).getModelState() != mState) {
             ((AppearanceStateHolder)blockEntity).updateAppearanceState(mState, world, pos);

--- a/src/main/java/foundationgames/enhancedblockentities/mixin/LifecycledResourceManagerImplMixin.java
+++ b/src/main/java/foundationgames/enhancedblockentities/mixin/LifecycledResourceManagerImplMixin.java
@@ -3,11 +3,11 @@ package foundationgames.enhancedblockentities.mixin;
 import foundationgames.enhancedblockentities.util.EBEUtil;
 import foundationgames.enhancedblockentities.util.ResourceUtil;
 import foundationgames.enhancedblockentities.util.hacks.ExperimentalSetup;
-import net.minecraft.resource.LifecycledResourceManagerImpl;
-import net.minecraft.resource.NamespaceResourceManager;
-import net.minecraft.resource.ResourceManager;
-import net.minecraft.resource.ResourcePack;
-import net.minecraft.resource.ResourceType;
+import net.minecraft.server.packs.PackResources;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.resources.FallbackResourceManager;
+import net.minecraft.server.packs.resources.ReloadableResourceManager;
+import net.minecraft.server.packs.resources.ResourceManager;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -20,12 +20,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-@Mixin(LifecycledResourceManagerImpl.class)
+@Mixin(ReloadableResourceManager.class)
 public abstract class LifecycledResourceManagerImplMixin {
-    @Shadow @Final          private Map<String, NamespaceResourceManager> subManagers;
+    @Shadow @Final private Map<String, FallbackResourceManager> namespacedPacks;
 
     @ModifyVariable(method = "<init>", at = @At(value = "INVOKE", target = "Ljava/util/List;copyOf(Ljava/util/Collection;)Ljava/util/List;", shift = At.Shift.BEFORE), ordinal = 0)
-    private List<ResourcePack> enhanced_bes$injectBasePack(List<ResourcePack> old) {
+    private List<PackResources> enhanced_bes$injectBasePack(List<PackResources> old) {
         var packs = new ArrayList<>(old);
 
         int idx = 0;
@@ -38,16 +38,16 @@ public abstract class LifecycledResourceManagerImplMixin {
     }
 
     @Inject(method = "<init>", at = @At(value = "TAIL"))
-    private void enhanced_bes$injectTopLevelPack(ResourceType type, List<ResourcePack> packs, CallbackInfo ci) {
+    private void enhanced_bes$injectTopLevelPack(PackType type, List<PackResources> packs, CallbackInfo ci) {
         ExperimentalSetup.cacheResources((ResourceManager) this);
         ExperimentalSetup.setup();
 
         addPack(type, ResourceUtil.getTopLevelPack());
     }
 
-    private void addPack(ResourceType type, ResourcePack pack) {
+    private void addPack(PackType type, PackResources pack) {
         for (var namespace : pack.getNamespaces(type)) {
-            this.subManagers.computeIfAbsent(namespace, n -> new NamespaceResourceManager(type, n)).addPack(pack);
+            this.namespacedPacks.computeIfAbsent(namespace, n -> new FallbackResourceManager(type, n)).push(pack);
         }
     }
 }

--- a/src/main/java/foundationgames/enhancedblockentities/mixin/MinecraftClientMixin.java
+++ b/src/main/java/foundationgames/enhancedblockentities/mixin/MinecraftClientMixin.java
@@ -1,7 +1,7 @@
 package foundationgames.enhancedblockentities.mixin;
 
 import foundationgames.enhancedblockentities.event.EBEEvents;
-import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.Minecraft;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -9,9 +9,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.concurrent.CompletableFuture;
 
-@Mixin(MinecraftClient.class)
+@Mixin(Minecraft.class)
 public class MinecraftClientMixin {
-    @Inject(method = "reloadResources()Ljava/util/concurrent/CompletableFuture;",
+    @Inject(method = "reloadResourcePacks()Ljava/util/concurrent/CompletableFuture;",
             at = @At("RETURN"))
     private void enhanced_bes$fireReloadEvent(CallbackInfoReturnable<CompletableFuture<Void>> cir) {
         cir.getReturnValue().thenAccept(v -> EBEEvents.RESOURCE_RELOAD.invoker().run());

--- a/src/main/java/foundationgames/enhancedblockentities/mixin/ShulkerBoxBlockEntityMixin.java
+++ b/src/main/java/foundationgames/enhancedblockentities/mixin/ShulkerBoxBlockEntityMixin.java
@@ -1,12 +1,12 @@
 package foundationgames.enhancedblockentities.mixin;
 
 import foundationgames.enhancedblockentities.util.duck.AppearanceStateHolder;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.block.entity.BlockEntityType;
-import net.minecraft.block.entity.ShulkerBoxBlockEntity;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.entity.ShulkerBoxBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ShulkerBoxBlockEntity.class)
 public abstract class ShulkerBoxBlockEntityMixin extends BlockEntity implements AppearanceStateHolder {
-    @Shadow public abstract float getAnimationProgress(float delta);
+    @Shadow public abstract float getProgress(float delta);
 
     @Unique private int enhanced_bes$modelState = 0;
     @Unique private int enhanced_bes$renderState = 0;
@@ -26,8 +26,8 @@ public abstract class ShulkerBoxBlockEntityMixin extends BlockEntity implements 
     }
 
     @Inject(method = "updateAnimation", at = @At("TAIL"))
-    private void enhanced_bes$updateModelState(World world, BlockPos pos, BlockState state, CallbackInfo ci) {
-        int mState = this.getAnimationProgress(0) > 0 ? 1 : 0;
+    private void enhanced_bes$updateModelState(Level world, BlockPos pos, BlockState state, CallbackInfo ci) {
+        int mState = this.getProgress(0) > 0 ? 1 : 0;
         if (mState != enhanced_bes$modelState) updateAppearanceState(mState, world, pos);
     }
 

--- a/src/main/java/foundationgames/enhancedblockentities/mixin/SignEditScreenMixin.java
+++ b/src/main/java/foundationgames/enhancedblockentities/mixin/SignEditScreenMixin.java
@@ -3,13 +3,13 @@ package foundationgames.enhancedblockentities.mixin;
 import foundationgames.enhancedblockentities.EnhancedBlockEntities;
 import foundationgames.enhancedblockentities.EnhancedBlockEntityRegistry;
 import foundationgames.enhancedblockentities.util.EBEUtil;
-import net.minecraft.block.BlockState;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.ingame.SignEditScreen;
-import net.minecraft.client.render.OverlayTexture;
-import net.minecraft.state.property.Properties;
-import net.minecraft.util.math.Direction;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.inventory.SignEditScreen;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.core.Direction;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -18,35 +18,35 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(SignEditScreen.class)
 public class SignEditScreenMixin {
     @Inject(method = "renderSignBackground", at = @At("HEAD"), cancellable = true)
-    private void enhanced_bes$renderBakedModelSign(DrawContext context, CallbackInfo ci) {
-        BlockState state = ((SignEditScreen) (Object) this).blockEntity.getCachedState();
+    private void enhanced_bes$renderBakedModelSign(GuiGraphics context, CallbackInfo ci) {
+        BlockState state = ((SignEditScreen) (Object) this).blockEntity.getBlockState();
 
         boolean enhanceSigns = EnhancedBlockEntities.CONFIG.renderEnhancedSigns;
 
         if (!EnhancedBlockEntityRegistry.BLOCKS.contains(state.getBlock())) return;
 
         if (enhanceSigns) {
-            var models = MinecraftClient.getInstance().getBakedModelManager().getBlockModels();
-            var buffers = MinecraftClient.getInstance().getBufferBuilders().getEntityVertexConsumers();
+            var models = Minecraft.getInstance().getModelManager().getBlockModelShaper();
+            var buffers = Minecraft.getInstance().renderBuffers().bufferSource();
             float up = 0;
-            if (state.contains(Properties.HORIZONTAL_FACING)) {
-                state = state.with(Properties.HORIZONTAL_FACING, Direction.SOUTH);
+            if (state.hasProperty(BlockStateProperties.HORIZONTAL_FACING)) {
+                state = state.setValue(BlockStateProperties.HORIZONTAL_FACING, Direction.SOUTH);
                 up += 5f/16;
-            } else if (state.contains(Properties.ROTATION)) {
-                state = state.with(Properties.ROTATION, 0);
+            } else if (state.hasProperty(BlockStateProperties.ROTATION_16)) {
+                state = state.setValue(BlockStateProperties.ROTATION_16, 0);
             }
 
-            var signModel = models.getModel(state);
-            var matrices = context.getMatrices();
+            var signModel = models.getBlockModel(state);
+            var matrices = context.pose();
 
-            matrices.push();
+            matrices.pushPose();
             matrices.translate(0, 31, -50);
             matrices.scale(93.75f, -93.75f, 93.75f);
             matrices.translate(-0.5, up - 0.5, 0);
 
-            EBEUtil.renderBakedModel(buffers, state, matrices, signModel, 15728880, OverlayTexture.DEFAULT_UV);
+            EBEUtil.renderBakedModel(buffers, state, matrices, signModel, 15728880, OverlayTexture.NO_OVERLAY);
 
-            matrices.pop();
+            matrices.popPose();
 
             ci.cancel();
         }

--- a/src/main/java/foundationgames/enhancedblockentities/mixin/VideoOptionsScreenMixin.java
+++ b/src/main/java/foundationgames/enhancedblockentities/mixin/VideoOptionsScreenMixin.java
@@ -1,17 +1,17 @@
 package foundationgames.enhancedblockentities.mixin;
 
 import foundationgames.enhancedblockentities.config.gui.option.ConfigButtonOption;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.option.VideoOptionsScreen;
-import net.minecraft.client.option.SimpleOption;
-import net.minecraft.text.Text;
+import net.minecraft.client.OptionInstance;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.VideoSettingsScreen;
+import net.minecraft.network.chat.Component;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
-@Mixin(VideoOptionsScreen.class)
+@Mixin(VideoSettingsScreen.class)
 public abstract class VideoOptionsScreenMixin extends Screen {
-    protected VideoOptionsScreenMixin(Text title) {
+    protected VideoOptionsScreenMixin(Component title) {
         super(title);
     }
 
@@ -19,12 +19,12 @@ public abstract class VideoOptionsScreenMixin extends Screen {
             method = "addOptions",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/client/gui/widget/OptionListWidget;addAll([Lnet/minecraft/client/option/SimpleOption;)V"
+                    target = "Lnet/minecraft/client/gui/components/OptionsList;addSmall([Lnet/minecraft/client/OptionInstance;)V"
             ),
             index = 0
     )
-    private SimpleOption<?>[] enhanced_bes$addEBEOptionButton(SimpleOption<?>[] old) {
-        var options = new SimpleOption<?>[old.length + 1];
+    private OptionInstance<?>[] enhanced_bes$addEBEOptionButton(OptionInstance<?>[] old) {
+        var options = new OptionInstance<?>[old.length + 1];
         System.arraycopy(old, 0, options, 0, old.length);
         options[options.length - 1] = ConfigButtonOption.getOption(this);
         return options;

--- a/src/main/java/foundationgames/enhancedblockentities/mixin/WorldRendererMixin.java
+++ b/src/main/java/foundationgames/enhancedblockentities/mixin/WorldRendererMixin.java
@@ -2,24 +2,25 @@ package foundationgames.enhancedblockentities.mixin;
 
 import foundationgames.enhancedblockentities.util.WorldUtil;
 import foundationgames.enhancedblockentities.util.duck.ChunkRebuildTaskAccess;
-import net.minecraft.client.render.WorldRenderer;
-import net.minecraft.client.render.chunk.ChunkBuilder;
-import net.minecraft.util.math.ChunkSectionPos;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.chunk.ChunkRenderDispatcher;
+import net.minecraft.world.level.ChunkPos;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(WorldRenderer.class)
+@Mixin(LevelRenderer.class)
 public class WorldRendererMixin {
 
-    @ModifyVariable(method = "updateChunks",
-            at = @At(value = "INVOKE", shift = At.Shift.BEFORE, ordinal = 0, target = "Lnet/minecraft/client/option/SimpleOption;getValue()Ljava/lang/Object;"),
+    @ModifyVariable(method = "applyFrustum",
+            at = @At(value = "INVOKE", shift = At.Shift.BEFORE, ordinal = 0, target = "Lnet/minecraft/client/OptionInstance;get()Ljava/lang/Object;"),
             index = 7)
-    private ChunkBuilder.BuiltChunk enhanced_bes$addPostRebuildTask(ChunkBuilder.BuiltChunk chunk) {
+    private ChunkRenderDispatcher.RenderChunk enhanced_bes$addPostRebuildTask(ChunkRenderDispatcher.RenderChunk chunk) {
         if (WorldUtil.CHUNK_UPDATE_TASKS.size() > 0) {
-            var pos = ChunkSectionPos.from(chunk.getOrigin());
+            var origin = chunk.getOrigin();
+            var pos = new ChunkPos(origin);
 
             if (WorldUtil.CHUNK_UPDATE_TASKS.containsKey(pos)) {
                 var task = WorldUtil.CHUNK_UPDATE_TASKS.remove(pos);
@@ -30,8 +31,8 @@ public class WorldRendererMixin {
         return chunk;
     }
 
-    @Inject(method = "addBuiltChunk", at = @At("HEAD"))
-    private void enhanced_bes$runPostRebuildTask(ChunkBuilder.BuiltChunk chunk, CallbackInfo ci) {
+    @Inject(method = "addRecentlyCompiledChunk", at = @At("HEAD"))
+    private void enhanced_bes$runPostRebuildTask(ChunkRenderDispatcher.RenderChunk chunk, CallbackInfo ci) {
         ((ChunkRebuildTaskAccess) chunk).enhanced_bes$runAfterRebuildTask();
     }
 }

--- a/src/main/java/foundationgames/enhancedblockentities/mixin/compat/sodium/RenderSectionManagerMixin.java
+++ b/src/main/java/foundationgames/enhancedblockentities/mixin/compat/sodium/RenderSectionManagerMixin.java
@@ -5,7 +5,7 @@ import foundationgames.enhancedblockentities.util.duck.ChunkRebuildTaskAccess;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSection;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSectionManager;
 import net.caffeinemc.mods.sodium.client.render.chunk.compile.BuilderTaskOutput;
-import net.minecraft.util.math.ChunkSectionPos;
+import net.minecraft.world.level.ChunkPos;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
@@ -23,7 +23,7 @@ public class RenderSectionManagerMixin {
     )
     private RenderSection enhanced_bes$compat_sodium$cacheUpdatingChunk(RenderSection section) {
         if (WorldUtil.CHUNK_UPDATE_TASKS.size() > 0) {
-            var pos = ChunkSectionPos.from(section.getChunkX(), section.getChunkY(), section.getChunkZ());
+            var pos = new ChunkPos(section.getChunkX(), section.getChunkZ());
 
             if (WorldUtil.CHUNK_UPDATE_TASKS.containsKey(pos)) {
                 var task = WorldUtil.CHUNK_UPDATE_TASKS.remove(pos);

--- a/src/main/java/foundationgames/enhancedblockentities/util/DateUtil.java
+++ b/src/main/java/foundationgames/enhancedblockentities/util/DateUtil.java
@@ -1,13 +1,13 @@
 package foundationgames.enhancedblockentities.util;
 
 import foundationgames.enhancedblockentities.EnhancedBlockEntities;
-import net.minecraft.client.render.block.entity.ChestBlockEntityRenderer;
+import net.minecraft.client.renderer.blockentity.ChestRenderer;
 
 public enum DateUtil {;
     public static boolean isChristmas() {
         String config = EnhancedBlockEntities.CONFIG.christmasChests;
         if (config.equals("disabled")) return false;
         if (config.equals("forced")) return true;
-        return ChestBlockEntityRenderer.isAroundChristmas();
+        return ChestRenderer.isChristmas();
     }
 }

--- a/src/main/java/foundationgames/enhancedblockentities/util/EBEUtil.java
+++ b/src/main/java/foundationgames/enhancedblockentities/util/EBEUtil.java
@@ -3,25 +3,25 @@ package foundationgames.enhancedblockentities.util;
 import foundationgames.enhancedblockentities.EnhancedBlockEntities;
 import net.fabricmc.fabric.api.renderer.v1.model.ModelHelper;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.block.BlockState;
-import net.minecraft.client.render.RenderLayers;
-import net.minecraft.client.render.VertexConsumer;
-import net.minecraft.client.render.VertexConsumerProvider;
-import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.render.model.BakedQuad;
-import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.resource.DefaultResourcePack;
-import net.minecraft.resource.ResourcePack;
-import net.minecraft.util.DyeColor;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.random.Random;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.PackResources;
+import net.minecraft.server.packs.resources.FallbackResourceManager;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.level.block.state.BlockState;
 
 import java.io.IOException;
 import java.nio.file.Files;
 
 public enum EBEUtil {;
-    private static final Random dummy = Random.create();
+    private static final RandomSource dummy = RandomSource.create();
 
     // Contains all dye colors, and null
     public static final DyeColor[] DEFAULTED_DYE_COLORS;
@@ -41,23 +41,25 @@ public enum EBEUtil {;
         return h >= 0 ? h * 90 : 0;
     }
 
-    public static void renderBakedModel(VertexConsumerProvider vertexConsumers, BlockState state, MatrixStack matrices, BakedModel model, int light, int overlay) {
-        VertexConsumer vertices = vertexConsumers.getBuffer(RenderLayers.getEntityBlockLayer(state));
+    public static void renderBakedModel(MultiBufferSource vertexConsumers, BlockState state, PoseStack matrices, BakedModel model, int light, int overlay) {
+        VertexConsumer vertices = vertexConsumers.getBuffer(net.minecraft.client.renderer.ItemBlockRenderTypes.getChunkRenderType(state));
         for (int i = 0; i <= 6; i++) {
             for (BakedQuad q : model.getQuads(null, ModelHelper.faceFromIndex(i), dummy)) {
-                vertices.quad(matrices.peek(), q, 1, 1, 1, 1, light, overlay);
+                vertices.putBulkData(matrices.last(), q, 1, 1, 1, 1, light, overlay);
             }
         }
     }
 
-    public static boolean isVanillaResourcePack(ResourcePack pack) {
-        return (pack instanceof DefaultResourcePack) ||
+    public static boolean isVanillaResourcePack(PackResources pack) {
+        // In Mojang mappings, check for vanilla pack by class name patterns
+        String className = pack.getClass().getName();
+        return className.contains("VanillaPackResources") || className.contains("DefaultResourcePack") ||
                 // Terrible quilt compat hack
-                ("org.quiltmc.qsl.resource.loader.api.GroupResourcePack$Wrapped".equals(pack.getClass().getName()));
+                ("org.quiltmc.qsl.resource.loader.api.GroupResourcePack$Wrapped".equals(className));
     }
 
-    public static Identifier id(String path) {
-        return Identifier.of(EnhancedBlockEntities.NAMESPACE, path);
+    public static ResourceLocation id(String path) {
+        return ResourceLocation.fromNamespaceAndPath(EnhancedBlockEntities.NAMESPACE, path);
     }
 
     public static final String DUMP_FOLDER_NAME = "enhanced_bes_dump";

--- a/src/main/java/foundationgames/enhancedblockentities/util/GuiUtil.java
+++ b/src/main/java/foundationgames/enhancedblockentities/util/GuiUtil.java
@@ -1,10 +1,10 @@
 package foundationgames.enhancedblockentities.util;
 
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
 
 public enum GuiUtil {;
-    public static Text shorten(String text, final int maxLength, Formatting ... formats) {
+    public static Component shorten(String text, final int maxLength, ChatFormatting ... formats) {
         String[] words = text.split(" ");
         StringBuilder line = new StringBuilder();
         StringBuilder result = new StringBuilder();
@@ -20,6 +20,6 @@ public enum GuiUtil {;
             }
         }
         if (line.length() > 0) result.append(line);
-        return Text.literal(result.toString()).formatted(formats);
+        return Component.literal(result.toString()).formatted(formats);
     }
 }

--- a/src/main/java/foundationgames/enhancedblockentities/util/ResourceUtil.java
+++ b/src/main/java/foundationgames/enhancedblockentities/util/ResourceUtil.java
@@ -5,12 +5,12 @@ import foundationgames.enhancedblockentities.client.resource.EBEPack;
 import foundationgames.enhancedblockentities.client.resource.template.TemplateProvider;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
-import net.minecraft.block.DecoratedPotPattern;
-import net.minecraft.client.render.TexturedRenderLayers;
-import net.minecraft.registry.RegistryKey;
-import net.minecraft.util.DyeColor;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.math.Direction;
+import net.minecraft.client.renderer.Sheets;
+import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.level.block.DecoratedPotPattern;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -27,19 +27,19 @@ public enum ResourceUtil {;
     private static EBEPack TOP_LEVEL_PACK;
 
     public static void addChestItemDefinition(String chestName, String centerChest, boolean hasChristmas, EBEPack pack) {
-        pack.addTemplateResource(Identifier.of("items/"+chestName+".json"),
+        pack.addTemplateResource(ResourceLocation.parse("items/"+chestName+".json"),
                 t -> t.load(hasChristmas ? "item/chest_item.json" : "item/chest_item_no_christmas.json",
                         d -> d.def("chest", centerChest)));
     }
 
     public static void addBedItemDefinition(String bedColor, EBEPack pack) {
-        pack.addTemplateResource(Identifier.of("items/"+bedColor+"_bed.json"),
+        pack.addTemplateResource(ResourceLocation.parse("items/"+bedColor+"_bed.json"),
                 t -> t.load("item/bed.json",
                         d -> d.def("head", bedColor + "_bed_head").def("foot", bedColor + "_bed_foot")));
 
-        pack.addTemplateResource(Identifier.of("models/item/"+bedColor+"_bed_head.json"),
+        pack.addTemplateResource(ResourceLocation.parse("models/item/"+bedColor+"_bed_head.json"),
                 t -> t.load("model/bed_head_item.json", d -> d.def("bed", bedColor)));
-        pack.addTemplateResource(Identifier.of("models/item/"+bedColor+"_bed_foot.json"),
+        pack.addTemplateResource(ResourceLocation.parse("models/item/"+bedColor+"_bed_foot.json"),
                 t -> t.load("model/bed_foot_item.json", d -> d.def("bed", bedColor)));
     }
 
@@ -109,8 +109,8 @@ public enum ResourceUtil {;
         );
     }
 
-    private static void addChestLikeModel(String parent, String chestTex, String chestName, Identifier id, EBEPack pack) {
-        pack.addTemplateResource(Identifier.of(id.getNamespace(), "models/" + id.getPath() + ".json"),
+    private static void addChestLikeModel(String parent, String chestTex, String chestName, ResourceLocation id, EBEPack pack) {
+        pack.addTemplateResource(ResourceLocation.fromNamespaceAndPath(id.getNamespace(), "models/" + id.getPath() + ".json"),
                 t -> t.load("model/chest_like.json", d -> d
                         .def("parent", parent)
                         .def("chest_tex", chestTex)
@@ -120,18 +120,18 @@ public enum ResourceUtil {;
     }
 
     public static void addSingleChestModels(String chestTex, String chestName, EBEPack pack) {
-        addChestLikeModel("template_chest_center", chestTex, chestName, Identifier.of("block/" + chestName + "_center"), pack);
-        addChestLikeModel("template_chest_center_lid", chestTex, chestName, Identifier.of("block/" + chestName + "_center_lid"), pack);
-        addChestLikeModel("template_chest_center_trunk", chestTex, chestName, Identifier.of("block/" + chestName + "_center_trunk"), pack);
+        addChestLikeModel("template_chest_center", chestTex, chestName, ResourceLocation.parse("block/" + chestName + "_center"), pack);
+        addChestLikeModel("template_chest_center_lid", chestTex, chestName, ResourceLocation.parse("block/" + chestName + "_center_lid"), pack);
+        addChestLikeModel("template_chest_center_trunk", chestTex, chestName, ResourceLocation.parse("block/" + chestName + "_center_trunk"), pack);
     }
 
     public static void addDoubleChestModels(String leftTex, String rightTex, String chestName, EBEPack pack) {
-        addChestLikeModel("template_chest_left", leftTex, chestName, Identifier.of("block/" + chestName + "_left"), pack);
-        addChestLikeModel("template_chest_left_lid", leftTex, chestName, Identifier.of("block/" + chestName + "_left_lid"), pack);
-        addChestLikeModel("template_chest_left_trunk", leftTex, chestName, Identifier.of("block/" + chestName + "_left_trunk"), pack);
-        addChestLikeModel("template_chest_right", rightTex, chestName, Identifier.of("block/" + chestName + "_right"), pack);
-        addChestLikeModel("template_chest_right_lid", rightTex, chestName, Identifier.of("block/" + chestName + "_right_lid"), pack);
-        addChestLikeModel("template_chest_right_trunk", rightTex, chestName, Identifier.of("block/" + chestName + "_right_trunk"), pack);
+        addChestLikeModel("template_chest_left", leftTex, chestName, ResourceLocation.parse("block/" + chestName + "_left"), pack);
+        addChestLikeModel("template_chest_left_lid", leftTex, chestName, ResourceLocation.parse("block/" + chestName + "_left_lid"), pack);
+        addChestLikeModel("template_chest_left_trunk", leftTex, chestName, ResourceLocation.parse("block/" + chestName + "_left_trunk"), pack);
+        addChestLikeModel("template_chest_right", rightTex, chestName, ResourceLocation.parse("block/" + chestName + "_right"), pack);
+        addChestLikeModel("template_chest_right_lid", rightTex, chestName, ResourceLocation.parse("block/" + chestName + "_right_lid"), pack);
+        addChestLikeModel("template_chest_right_trunk", rightTex, chestName, ResourceLocation.parse("block/" + chestName + "_right_trunk"), pack);
     }
 
     private static String chestParticle(String chestName) {
@@ -149,13 +149,13 @@ public enum ResourceUtil {;
         return "";
     }
 
-    private static void addBlockState(Identifier id, TemplateProvider.TemplateApplyingFunction vars, EBEPack pack) {
-        pack.addTemplateResource(Identifier.of(id.getNamespace(), "blockstates/" + id.getPath() + ".json"),
+    private static void addBlockState(ResourceLocation id, TemplateProvider.TemplateApplyingFunction vars, EBEPack pack) {
+        pack.addTemplateResource(ResourceLocation.fromNamespaceAndPath(id.getNamespace(), "blockstates/" + id.getPath() + ".json"),
                 t -> t.load("blockstate/base.json", d -> d.def("vars", vars)));
     }
 
     public static void addChestBlockStates(String chestName, EBEPack pack) {
-        addBlockState(Identifier.of(chestName),
+        addBlockState(ResourceLocation.parse(chestName),
                 t0 -> list(
                         variantHFacing(t0, "type=single,facing=", "builtin:"+chestName+"_center"),
                         variantHFacing(t0, "type=left,facing=", "builtin:"+chestName+"_left"),
@@ -164,19 +164,19 @@ public enum ResourceUtil {;
     }
 
     public static void addSingleChestOnlyBlockStates(String chestName, EBEPack pack) {
-        addBlockState(Identifier.of(chestName),
+        addBlockState(ResourceLocation.parse(chestName),
                 t0 -> list(
                         variantHFacing(t0, "facing=", "builtin:"+chestName+"_center")
                 ), pack);
     }
 
-    public static void addParentModel(String parent, Identifier id, EBEPack pack) {
-        pack.addTemplateResource(Identifier.of(id.getNamespace(), "models/" + id.getPath() + ".json"), t ->
+    public static void addParentModel(String parent, ResourceLocation id, EBEPack pack) {
+        pack.addTemplateResource(ResourceLocation.fromNamespaceAndPath(id.getNamespace(), "models/" + id.getPath() + ".json"), t ->
                 "{" + kv("parent", parent) + "}");
     }
 
-    public static void addParentTexModel(String parent, String textures, Identifier id, EBEPack pack) {
-        pack.addTemplateResource(Identifier.of(id.getNamespace(), "models/" + id.getPath() + ".json"), t ->
+    public static void addParentTexModel(String parent, String textures, ResourceLocation id, EBEPack pack) {
+        pack.addTemplateResource(ResourceLocation.fromNamespaceAndPath(id.getNamespace(), "models/" + id.getPath() + ".json"), t ->
                 t.load("model/parent_and_tex.json", d -> d.def("parent", parent).def("textures", textures)));
     }
 
@@ -197,16 +197,16 @@ public enum ResourceUtil {;
                 ResourceUtil::signAOSuffix, pack);
 
         addParentTexModel(signAOSuffix("block/template_wall_sign"),
-                signParticle(signName) + kv("sign", signTex), Identifier.of("block/"+signType+"_wall_sign"), pack);
+                signParticle(signName) + kv("sign", signTex), ResourceLocation.parse("block/"+signType+"_wall_sign"), pack);
         addParentTexModel(signAOSuffix("block/template_wall_hanging_sign"),
-                hangingTexDef, Identifier.of("block/"+signType+"_wall_hanging_sign"), pack);
+                hangingTexDef, ResourceLocation.parse("block/"+signType+"_wall_hanging_sign"), pack);
     }
 
     public static void addRotation16Models(String textures, String templatePrefix, String modelPrefix, Function<String, String> suffix, EBEPack pack) {
-        addParentTexModel(suffix.apply(templatePrefix+"_0"), textures, Identifier.of(modelPrefix + "_0"), pack);
-        addParentTexModel(suffix.apply(templatePrefix+"_22_5"), textures, Identifier.of(modelPrefix + "_22_5"), pack);
-        addParentTexModel(suffix.apply(templatePrefix+"_45"), textures, Identifier.of(modelPrefix + "_45"), pack);
-        addParentTexModel(suffix.apply(templatePrefix+"_67_5"), textures, Identifier.of(modelPrefix + "_67_5"), pack);
+        addParentTexModel(suffix.apply(templatePrefix+"_0"), textures, ResourceLocation.parse(modelPrefix + "_0"), pack);
+        addParentTexModel(suffix.apply(templatePrefix+"_22_5"), textures, ResourceLocation.parse(modelPrefix + "_22_5"), pack);
+        addParentTexModel(suffix.apply(templatePrefix+"_45"), textures, ResourceLocation.parse(modelPrefix + "_45"), pack);
+        addParentTexModel(suffix.apply(templatePrefix+"_67_5"), textures, ResourceLocation.parse(modelPrefix + "_67_5"), pack);
     }
 
     private static String signAOSuffix(String model) {
@@ -215,25 +215,25 @@ public enum ResourceUtil {;
     }
 
     public static void addSignBlockStates(String signName, String wallSignName, EBEPack pack) {
-        addBlockState(Identifier.of(signName),
+        addBlockState(ResourceLocation.parse(signName),
                 t -> variantRotation16(t, "rotation=", "block/"+signName), pack);
-        addBlockState(Identifier.of(wallSignName),
+        addBlockState(ResourceLocation.parse(wallSignName),
                 t -> variantHFacing(t, "facing=", "block/"+wallSignName), pack);
     }
 
     public static void addHangingSignBlockStates(String signName, String wallSignName, EBEPack pack) {
-        addBlockState(Identifier.of(signName),
+        addBlockState(ResourceLocation.parse(signName),
                 t -> list(
                         variantRotation16(t, "attached=false,rotation=", "block/"+signName),
                         variantRotation16(t, "attached=true,rotation=", "block/"+signName+"_attached")
                 ), pack);
 
-        addBlockState(Identifier.of(wallSignName),
+        addBlockState(ResourceLocation.parse(wallSignName),
                 t -> variantHFacing(t, "facing=", "block/"+wallSignName), pack);
     }
 
     public static void addBellBlockState(EBEPack pack) {
-        addBlockState(Identifier.of("bell"),
+        addBlockState(ResourceLocation.parse("bell"),
                 t -> {
                     var vars = new DelimitedAppender(",");
                     for (Direction dir : EBEUtil.HORIZONTAL_DIRECTIONS) {
@@ -253,17 +253,17 @@ public enum ResourceUtil {;
 
         addParentTexModel(bedAOSuffix("block/template_bed_head"),
                 bedParticle(color) + kv("bed", "entity/bed/" + color),
-                Identifier.of("block/" + color + "_bed_head"), pack);
+                ResourceLocation.parse("block/" + color + "_bed_head"), pack);
         addParentTexModel(bedAOSuffix("block/template_bed_foot"),
                 bedParticle(color) + kv("bed", "entity/bed/" + color),
-                Identifier.of("block/" + color + "_bed_foot"), pack);
+                ResourceLocation.parse("block/" + color + "_bed_foot"), pack);
 
         addBedItemDefinition(color, pack);
     }
 
     public static void addBedBlockState(DyeColor bedColor, EBEPack pack) {
         String color = bedColor.getName();
-        addBlockState(Identifier.of(color + "_bed"),
+        addBlockState(ResourceLocation.parse(color + "_bed"),
                 t -> {
                     var vars = new DelimitedAppender(",");
                     for (Direction dir : EBEUtil.HORIZONTAL_DIRECTIONS) {
@@ -287,18 +287,18 @@ public enum ResourceUtil {;
         var particle = "block/"+shulkerBoxStr;
         addParentTexModel("block/template_shulker_box",
                 list(kv("shulker", texture), kv("particle", particle)),
-                Identifier.of("block/"+shulkerBoxStr), pack);
+                ResourceLocation.parse("block/"+shulkerBoxStr), pack);
         addParentTexModel("block/template_shulker_box_bottom",
                 list(kv("shulker", texture), kv("particle", particle)),
-                Identifier.of("block/"+shulkerBoxStr+"_bottom"), pack);
+                ResourceLocation.parse("block/"+shulkerBoxStr+"_bottom"), pack);
         addParentTexModel("block/template_shulker_box_lid",
                 list(kv("shulker", texture), kv("particle", particle)),
-                Identifier.of("block/"+shulkerBoxStr+"_lid"), pack);
+                ResourceLocation.parse("block/"+shulkerBoxStr+"_lid"), pack);
     }
 
     public static void addShulkerBoxBlockStates(@Nullable DyeColor color, EBEPack pack) {
         var shulkerBoxStr = color != null ? color.getName()+"_shulker_box" : "shulker_box";
-        addBlockState(Identifier.of(shulkerBoxStr),
+        addBlockState(ResourceLocation.parse(shulkerBoxStr),
                 t -> {
                     var vars = new DelimitedAppender(",");
                     vars
@@ -313,15 +313,15 @@ public enum ResourceUtil {;
     }
 
     public static void addDecoratedPotBlockState(EBEPack pack) {
-        addBlockState(Identifier.of("decorated_pot"),
+        addBlockState(ResourceLocation.parse("decorated_pot"),
                 t -> variantHFacing(t, "facing=", "builtin:decorated_pot"), pack);
     }
 
-    public static void addDecoratedPotPatternModels(RegistryKey<DecoratedPotPattern> patternKey, EBEPack pack) {
+    public static void addDecoratedPotPatternModels(ResourceKey<DecoratedPotPattern> patternKey, EBEPack pack) {
         for (Direction dir : EBEUtil.HORIZONTAL_DIRECTIONS) {
             addParentTexModel("block/template_pottery_pattern_" + dir.getName(),
-                    kv("pattern", TexturedRenderLayers.getDecoratedPotPatternTextureId(patternKey).getTextureId().toString()),
-                    Identifier.of("block/" + patternKey.getValue().getPath() + "_" + dir.getName()),
+                    kv("pattern", Sheets.getDecoratedPotMaterial(patternKey).texture().toString()),
+                    ResourceLocation.parse("block/" + patternKey.location().getPath() + "_" + dir.getName()),
                     pack);
         }
     }

--- a/src/main/java/foundationgames/enhancedblockentities/util/WorldUtil.java
+++ b/src/main/java/foundationgames/enhancedblockentities/util/WorldUtil.java
@@ -3,12 +3,12 @@ package foundationgames.enhancedblockentities.util;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.world.ClientWorld;
-import net.minecraft.registry.RegistryKey;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkSectionPos;
-import net.minecraft.world.World;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.ChunkPos;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,30 +16,30 @@ import java.util.Map;
 public enum WorldUtil implements ClientTickEvents.EndWorldTick {
     EVENT_LISTENER;
 
-    public static final Map<ChunkSectionPos, ExecutableRunnableHashSet> CHUNK_UPDATE_TASKS = new HashMap<>();
-    private static final Map<RegistryKey<World>, Long2ObjectMap<Runnable>> TIMED_TASKS = new HashMap<>();
+    public static final Map<ChunkPos, ExecutableRunnableHashSet> CHUNK_UPDATE_TASKS = new HashMap<>();
+    private static final Map<ResourceKey<Level>, Long2ObjectMap<Runnable>> TIMED_TASKS = new HashMap<>();
 
-    public static void rebuildChunk(World world, BlockPos pos) {
+    public static void rebuildChunk(Level world, BlockPos pos) {
         var state = world.getBlockState(pos);
-        MinecraftClient.getInstance().worldRenderer.updateBlock(world, pos, state, state, 8);
+        Minecraft.getInstance().levelRenderer.blockChanged(world, pos, state, state, 8);
     }
 
-    public static void rebuildChunkAndThen(World world, BlockPos pos, Runnable action) {
-        CHUNK_UPDATE_TASKS.computeIfAbsent(ChunkSectionPos.from(pos), k -> new ExecutableRunnableHashSet()).add(action);
+    public static void rebuildChunkAndThen(Level world, BlockPos pos, Runnable action) {
+        CHUNK_UPDATE_TASKS.computeIfAbsent(new ChunkPos(pos), k -> new ExecutableRunnableHashSet()).add(action);
         rebuildChunk(world, pos);
     }
 
-    public static void scheduleTimed(World world, long time, Runnable action) {
-        TIMED_TASKS.computeIfAbsent(world.getRegistryKey(), k -> new Long2ObjectOpenHashMap<>()).put(time, action);
+    public static void scheduleTimed(Level world, long time, Runnable action) {
+        TIMED_TASKS.computeIfAbsent(world.dimension(), k -> new Long2ObjectOpenHashMap<>()).put(time, action);
     }
 
     @Override
-    public void onEndTick(ClientWorld world) {
-        var key = world.getRegistryKey();
+    public void onEndTick(ClientLevel world) {
+        var key = world.dimension();
 
         if (TIMED_TASKS.containsKey(key)) {
             TIMED_TASKS.get(key).long2ObjectEntrySet().removeIf(entry -> {
-                if (world.getTime() >= entry.getLongKey()) {
+                if (world.getGameTime() >= entry.getLongKey()) {
                     entry.getValue().run();
                     return true;
                 }

--- a/src/main/java/foundationgames/enhancedblockentities/util/duck/AppearanceStateHolder.java
+++ b/src/main/java/foundationgames/enhancedblockentities/util/duck/AppearanceStateHolder.java
@@ -1,8 +1,8 @@
 package foundationgames.enhancedblockentities.util.duck;
 
 import foundationgames.enhancedblockentities.util.WorldUtil;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
 
 public interface AppearanceStateHolder {
     int getModelState();
@@ -13,8 +13,8 @@ public interface AppearanceStateHolder {
 
     void setRenderState(int state);
 
-    default void updateAppearanceState(int state, World world, BlockPos pos) {
-        if (!world.isClient()) {
+    default void updateAppearanceState(int state, Level world, BlockPos pos) {
+        if (!world.isClientSide()) {
             return;
         }
 

--- a/src/main/java/foundationgames/enhancedblockentities/util/hacks/ExperimentalSetup.java
+++ b/src/main/java/foundationgames/enhancedblockentities/util/hacks/ExperimentalSetup.java
@@ -4,8 +4,8 @@ import foundationgames.enhancedblockentities.EnhancedBlockEntities;
 import foundationgames.enhancedblockentities.client.resource.EBEPack;
 import foundationgames.enhancedblockentities.config.EBEConfig;
 import foundationgames.enhancedblockentities.util.ResourceUtil;
-import net.minecraft.resource.ResourceManager;
-import net.minecraft.util.DyeColor;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.world.item.DyeColor;
 
 import java.io.IOException;
 

--- a/src/main/java/foundationgames/enhancedblockentities/util/hacks/ResourceHacks.java
+++ b/src/main/java/foundationgames/enhancedblockentities/util/hacks/ResourceHacks.java
@@ -1,18 +1,18 @@
 package foundationgames.enhancedblockentities.util.hacks;
 
 import foundationgames.enhancedblockentities.client.resource.EBEPack;
-import net.minecraft.resource.ResourceManager;
-import net.minecraft.util.Identifier;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.NoSuchElementException;
 
 public enum ResourceHacks {;
-    private static void cropAndPutTexture(Identifier source, Identifier result, ResourceManager manager, EBEPack pack, float u0, float v0, float u1, float v1) throws IOException {
+    private static void cropAndPutTexture(ResourceLocation source, ResourceLocation result, ResourceManager manager, EBEPack pack, float u0, float v0, float u1, float v1) throws IOException {
         InputStream image;
         try {
-            image = manager.getResource(source).orElseThrow().getInputStream();
+            image = manager.getResource(source).orElseThrow().open();
         } catch (IOException | NoSuchElementException e) {
             return;
         }
@@ -24,7 +24,7 @@ public enum ResourceHacks {;
 
     public static void addChestParticleTexture(String chestName, String chestTexture, ResourceManager manager, EBEPack pack) throws IOException {
         cropAndPutTexture(
-                Identifier.of("textures/"+chestTexture+".png"), Identifier.of("textures/block/"+chestName+"_particle.png"),
+                ResourceLocation.parse("textures/"+chestTexture+".png"), ResourceLocation.parse("textures/block/"+chestName+"_particle.png"),
                 manager, pack,
                 42f/64, 33f/64, 58f/64, 49f/64
         );
@@ -32,7 +32,7 @@ public enum ResourceHacks {;
 
     public static void addBedParticleTexture(String bedColor, String bedTexture, ResourceManager manager, EBEPack pack) throws IOException {
         cropAndPutTexture(
-                Identifier.of("textures/"+bedTexture+".png"), Identifier.of("textures/block/"+bedColor+"_bed_particle.png"),
+                ResourceLocation.parse("textures/"+bedTexture+".png"), ResourceLocation.parse("textures/block/"+bedColor+"_bed_particle.png"),
                 manager, pack,
                 18f/64, 6f/64, 34f/64, 22f/64
         );
@@ -40,7 +40,7 @@ public enum ResourceHacks {;
 
     public static void addSignParticleTexture(String signType, String signTexture, ResourceManager manager, EBEPack pack) throws IOException {
         cropAndPutTexture(
-                Identifier.of("textures/"+signTexture+".png"), Identifier.of("textures/block/"+signType+"_sign_particle.png"),
+                ResourceLocation.parse("textures/"+signTexture+".png"), ResourceLocation.parse("textures/block/"+signType+"_sign_particle.png"),
                 manager, pack,
                 0, 3f/32, 16f/64, 19f/32
         );

--- a/src/main/resources/enhancedblockentities.accesswidener
+++ b/src/main/resources/enhancedblockentities.accesswidener
@@ -1,6 +1,6 @@
-accessWidener   v2      named
+accessWidener   v2      official
 
-accessible      class   net/minecraft/client/option/SimpleOption$Callbacks
-accessible      class   net/minecraft/client/render/model/BakedModelManager$BakingResult
-accessible      field   net/minecraft/client/gui/screen/ingame/AbstractSignEditScreen blockEntity Lnet/minecraft/block/entity/SignBlockEntity;
-accessible      method  net/minecraft/client/texture/NativeImage write (Ljava/nio/channels/WritableByteChannel;)Z
+accessible      class   net/minecraft/client/OptionInstance$Callbacks
+accessible      class   net/minecraft/client/resources/model/ModelManager$BakingResult
+accessible      field   net/minecraft/client/gui/screens/inventory/AbstractSignEditScreen blockEntity Lnet/minecraft/world/level/block/entity/SignBlockEntity;
+accessible      method  com/mojang/blaze3d/platform/NativeImage write (Ljava/nio/channels/WritableByteChannel;)Z

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,9 +31,9 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.16.7",
-    "fabric-api": ">=0.114.1",
-    "minecraft": ">=1.21.3"
+    "fabricloader": ">=0.19.3",
+    "fabric-api": ">=0.153.0",
+    "minecraft": ">=26.2"
   },
   "breaks": {
     "optifabric": "*"


### PR DESCRIPTION
## ⏱️ Hours Wasted Counter

> **Change this number if you also banged your head against this:**
>
> ### 🕐 8

---

## What this PR is

This is a **documentation draft**, not a working port. It captures everything discovered during ~8 hours of attempting to port EBE to Minecraft Java Edition 26.2 (internal: 1.21.11) on 2026-06-27.

**Short answer: EBE cannot be ported 1:1 to MC 26.2** because the rendering system EBE was built on top of has been fundamentally replaced.

---

## What was done

- ✅ Forked + created `26.2` branch
- ✅ Gradle 9.5.1, Fabric Loom 1.17, Java 25 build toolchain working
- ✅ GitHub Actions CI configured (JDK 25, triggers on `26.2` branch)
- ✅ All Fabric API / Sodium / ModMenu versions updated for 26.2
- ✅ Access widener migrated to `official` namespace (MC 26.x ships **without obfuscation** — no `client_mappings` in launcher manifest)
- ✅ Full source migration from Yarn 1.21.4 → Mojang 26.x naming (~50 files, ~750 line changes)
- ❌ Does not compile — blocked on architectural mismatches described below

---

## The wall we hit: MC 26.x overhauled the rendering pipeline

### 1. `BakedModel` → `BlockStateModel`
The `BakedModel` interface that EBE uses to render block entities as static geometry has been replaced by `BlockStateModel` in `net.minecraft.client.renderer.block.dispatch`. This is a different interface with a different rendering contract. All of EBE's model loading, baking, and rendering logic targets `BakedModel`.

### 2. Block entity rendering is now two-phase (Entity Render State)
The old injection point in `BlockEntityRenderDispatcher.render(BlockEntityRenderer, BlockEntity, float, MatrixStack, VertexConsumerProvider)` no longer exists in the same form. MC 26.x uses a two-phase approach:
1. **State extraction** (game thread): `BlockEntity` → `BlockEntityRenderState`
2. **Rendering** (render thread): `BlockEntityRenderState` → pixels

EBE needs to intercept one of these phases instead of the old single `render()` call. Which phase and how is not obvious.

### 3. `FabricBakedModelManager.getModel(Identifier)` → `FabricModelManager.getModel(ExtraModelKey<T>)`
The Fabric API model loading changed from identifier-based lookup to typed key-based lookup. EBE's entire `ModelIdentifiers` class (100+ constants) and model registration/retrieval system needs to be rethought around `ExtraModelKey<T>`.

### 4. `BlockRenderLayerMap` removed from Fabric API
EBE calls `BlockRenderLayerMap.INSTANCE.putBlock(block, RenderLayer.getCutoutMipped())` for chests, shulker boxes, and hanging signs. This API is gone in Fabric 26.2 with no direct replacement visible in the source tree.

### 5. `ResourceLocation` → `Identifier` (again)
Mojang renamed `ResourceLocation` back to `Identifier` in MC 26.x (now in `net.minecraft.resources.Identifier` instead of `net.minecraft.util.Identifier`). They also removed obfuscation entirely. This was a "fun" discovery.

### 6. Vertex/render consumer pipeline changed
`VertexConsumerProvider` / `MultiBufferSource` is no longer the entry point for chunk geometry submission. The new pipeline uses `SubmitNodeCollector` and related classes. EBE's chunk injection points in `WorldRendererMixin` and Sodium's `RenderSectionManagerMixin` both target methods that no longer exist.

---

## Is EBE still relevant in 26.x?

Genuinely unclear. Mojang's `BlockEntityRenderState` system was specifically designed to address the same problem EBE solved — separating state extraction from rendering to allow caching and parallelism. The new pipeline may already provide most of the performance benefit.

The one remaining gap might be **ambient occlusion and lighting quality** for block entities (static `BlockStateModel` geometry gets full chunk AO; block entity render states may not). If that gap exists in 26.x vanilla, a slimmed-down EBE focused only on AO/lighting quality rather than full static baking could still be worthwhile.

---

## Build artifacts

The `26.2` branch in [dubsector/EnhancedBlockEntities](https://github.com/dubsector/EnhancedBlockEntities/tree/26.2) has the build scaffolding working. It fails at compile time on the rendering API mismatches above, not on build system issues.

CI: https://github.com/dubsector/EnhancedBlockEntities/actions